### PR TITLE
Updating Github action versions + post PR functionality

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   push_to_registry:
-    name: Push a container image to quay.io/medik8s
+    name: Build and push images to quay.io/medik8s
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -30,9 +30,9 @@ jobs:
 
       - name: Build and push operator and bundle images, using version 0.0.1, for pushes to main
         if: ${{ github.ref_type != 'tag' }}
-        run: export VERSION=0.0.1 && make docker-build bundle bundle-build docker-push bundle-push
+        run: make container-build container-push
 
-      - name: Build and push versioned operator and bundle images, for tags
+      - name: Build and push versioned CSV and images, for tags
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make docker-build bundle bundle-build docker-push bundle-push
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build container-push

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
 

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -1,5 +1,5 @@
-name: Go
-on:
+name: Pre Submit # workflow name
+on: # on events
   push:
     branches:
       - main
@@ -22,8 +22,11 @@ jobs:
       with:
         go-version: 1.18
 
-    - name: Build and test
-      run: make manifests generate docker-build
+    - name: Run checks and unit tests
+      run: make test
+
+    - name: Test container build
+      run: make container-build
 
     - name: TestMutations
       run: make test-mutation-ci

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,32 @@
 # SHELL defines bash so all the inline scripts here will work as expected.
 SHELL := /bin/bash
 
-# Current Operator version
+# IMAGE_REGISTRY used to indicate the registery/group for the operator, bundle and catalog
+IMAGE_REGISTRY ?= quay.io/medik8s
+export IMAGE_REGISTRY
 
+
+# When no version is set, use latest as image tags
+DEFAULT_VERSION := 0.0.1
+ifeq ($(origin VERSION), undefined)
+IMAGE_TAG = latest
+else ifeq ($(VERSION), $(DEFAULT_VERSION))
+IMAGE_TAG = latest
+else
+IMAGE_TAG = v$(VERSION)
+endif
+export IMAGE_TAG
+CHANNELS = stable
+export CHANNELS
+DEFAULT_CHANNEL = stable
+export DEFAULT_CHANNEL
 # VERSION defines the project version for the bundle. 
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-export VERSION ?= $(shell git describe --match="v*"| sed 's/v//')
-
-# use stable channel
-CHANNELS = stable
+VERSION ?= $(DEFAULT_VERSION)
+export VERSION
 
 # CHANNELS define the bundle channels used in the bundle. 
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")
@@ -32,12 +47,21 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-# BUNDLE_IMG defines the image:tag used for the bundle. 
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= quay.io/medik8s/self-node-remediation-operator-bundle:$(VERSION)
+OPERATOR_NAME ?= self-node-remediation
 
-# Image URL to use building/pushing operator image
-export IMG ?= quay.io/medik8s/self-node-remediation-operator:$(VERSION)
+# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
+# This variable is used to construct full image tags for bundle and catalog images.
+#
+# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
+# medik8s/self-node-remediation-bundle:$(IMAGE_TAG) and medik8s/self-node-remediation-catalog:$(IMAGE_TAG).
+IMAGE_TAG_BASE ?= $(IMAGE_REGISTRY)/$(OPERATOR_NAME)
+
+# BUNDLE_IMG defines the image:tag used for the bundle.
+# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-operator-bundle:$(IMAGE_TAG)
+
+# Image URL to use all building/pushing image targets
+export IMG ?= $(IMAGE_TAG_BASE)-operator:$(IMAGE_TAG)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
@@ -121,9 +145,11 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+.PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
+.PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
 
@@ -178,12 +204,12 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-.PHONY: bundle ## Generate bundle manifests and metadata, then validate generated files.
-bundle: manifests operator-sdk kustomize
+.PHONY: bundle
+bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	sed -r -i "s|createdAt: \".*\"|createdAt: \"`date "+%Y-%m-%d %T" `\"|;" ./config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
-	sed -r -i "s|containerImage: .*|containerImage: ${IMG}|;" ./config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
+	sed -r -i "s|createdAt: \".*\"|createdAt: \"`date "+%Y-%m-%d %T" `\"|;" ./config/manifests/bases/$(OPERATOR_NAME).clusterserviceversion.yaml
+	sed -r -i "s|containerImage: .*|containerImage: ${IMG}|;" ./config/manifests/bases/$(OPERATOR_NAME).clusterserviceversion.yaml
 	$(KUSTOMIZE) build config/manifests | envsubst | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 


### PR DESCRIPTION
- Updating GitHub Action versions (similar to [NMO PR](https://github.com/medik8s/node-maintenance-operator/pull/24) and [NHC PR](https://github.com/medik8s/node-healthcheck-operator/pull/98)):
  - [actions/checkout](https://github.com/actions/checkout/tree/main) and  [actions/setup-go](https://github.com/actions/setup-go/tree/main) versions from 2 to 3.
  - [docker/login-action](https://github.com/docker/login-action) from version 1 to 2.
- Using `IMAGE_TAG` instead of `VERSION`.
- Adding _bundle_ and _catalog_ `build` and `push` and two new targets (`container-build` & `container-push`) for CI in Makefile.
