### PR TITLE
Add node Taint remediation

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -24,6 +24,7 @@ import (
 const (
 	NodeDeletionRemediationStrategy     = RemediationStrategyType("NodeDeletion")
 	ResourceDeletionRemediationStrategy = RemediationStrategyType("ResourceDeletion")
+	AddTaintRemediationStrategy         = RemediationStrategyType("AddTaint")
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -34,11 +35,11 @@ type RemediationStrategyType string
 // SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
 type SelfNodeRemediationSpec struct {
 	//RemediationStrategy is the remediation method for unhealthy nodes
-	//could be either "NodeDeletion" or "ResourceDeletion"
+	//could be either "NodeDeletion", "ResourceDeletion" or "AddTaint"
 	//the first will delete the node to signal to the cluster that the node was fenced
 	//the latter will iterate over all pos and volumeattachments related to the unhealthy node and delete them
 	// +kubebuilder:default:="ResourceDeletion"
-	// +kubebuilder:validation:Enum=NodeDeletion;ResourceDeletion
+	// +kubebuilder:validation:Enum=NodeDeletion;ResourceDeletion;AddTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -43,13 +43,14 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes could be either "NodeDeletion" or "ResourceDeletion" the first
-                  will delete the node to signal to the cluster that the node was
-                  fenced the latter will iterate over all pos and volumeattachments
+                  nodes could be either "NodeDeletion", "ResourceDeletion" or "AddTaint"
+                  the first will delete the node to signal to the cluster that the
+                  node was fenced the latter will iterate over all pos and volumeattachments
                   related to the unhealthy node and delete them
                 enum:
                 - NodeDeletion
                 - ResourceDeletion
+                - AddTaint
                 type: string
             type: object
           status:

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -52,14 +52,15 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes could be either "NodeDeletion" or "ResourceDeletion"
-                          the first will delete the node to signal to the cluster
-                          that the node was fenced the latter will iterate over all
-                          pos and volumeattachments related to the unhealthy node
-                          and delete them
+                          for unhealthy nodes could be either "NodeDeletion", "ResourceDeletion"
+                          or "AddTaint" the first will delete the node to signal to
+                          the cluster that the node was fenced the latter will iterate
+                          over all pos and volumeattachments related to the unhealthy
+                          node and delete them
                         enum:
                         - NodeDeletion
                         - ResourceDeletion
+                        - AddTaint
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -42,13 +42,14 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes could be either "NodeDeletion" or "ResourceDeletion" the first
-                  will delete the node to signal to the cluster that the node was
-                  fenced the latter will iterate over all pos and volumeattachments
+                  nodes could be either "NodeDeletion", "ResourceDeletion" or "AddTaint"
+                  the first will delete the node to signal to the cluster that the
+                  node was fenced the latter will iterate over all pos and volumeattachments
                   related to the unhealthy node and delete them
                 enum:
                 - NodeDeletion
                 - ResourceDeletion
+                - AddTaint
                 type: string
             type: object
           status:

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -51,14 +51,15 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes could be either "NodeDeletion" or "ResourceDeletion"
-                          the first will delete the node to signal to the cluster
-                          that the node was fenced the latter will iterate over all
-                          pos and volumeattachments related to the unhealthy node
-                          and delete them
+                          for unhealthy nodes could be either "NodeDeletion", "ResourceDeletion"
+                          or "AddTaint" the first will delete the node to signal to
+                          the cluster that the node was fenced the latter will iterate
+                          over all pos and volumeattachments related to the unhealthy
+                          node and delete them
                         enum:
                         - NodeDeletion
                         - ResourceDeletion
+                        - AddTaint
                         type: string
                     type: object
                 required:


### PR DESCRIPTION
This PR is the first attempt to implementing NEC requirments defined in  [this](https://issues.redhat.com/browse/ECOPROJECT-777) ticket.

**Implementation high level details**
 
 Added a new remediation strategy "Add Taint" (the following is relevant for this strategy):
1. Upon CR detection set NoExucte taint on the Node & add finalizer to the CR
2. This should trigger the actual remediation (implemented in the API Server)
3. When remediation is successful NHC will try to delete the CR
4. When CR is attempted to be deleted, remove the finalizer from the CR & the taint from the Node