### PR TITLE
Add/Remove No Execute Taint

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -366,28 +366,26 @@ func verifyFinalizerExists() {
 
 func verifyNoExecuteTaintRemoved() {
 	By("Verify that node does not have NoExecute taint")
-	Eventually(isNoExecuteTaintExist(), 10*time.Second, 200*time.Millisecond).Should(BeFalse())
+	Eventually(isNoExecuteTaintExist, 10*time.Second, 200*time.Millisecond).Should(BeFalse())
 }
 
 func verifyNoExecuteTaintExist() {
 	By("Verify that node has NoExecute taint")
-	Eventually(isNoExecuteTaintExist(), 10*time.Second, 200*time.Millisecond).Should(BeTrue())
+	Eventually(isNoExecuteTaintExist, 10*time.Second, 200*time.Millisecond).Should(BeTrue())
 }
 
-func isNoExecuteTaintExist() func() bool {
+func isNoExecuteTaintExist() (bool, error) {
 	node := &v1.Node{}
-	return func() bool {
-		err := k8sClient.Reader.Get(context.TODO(), unhealthyNodeNamespacedName, node)
-		if err != nil {
-			return false
-		}
-		for _, taint := range node.Spec.Taints {
-			if controllers.NodeNoExecuteTaint.MatchTaint(&taint) {
-				return true
-			}
-		}
-		return false
+	err := k8sClient.Reader.Get(context.TODO(), unhealthyNodeNamespacedName, node)
+	if err != nil {
+		return false, err
 	}
+	for _, taint := range node.Spec.Taints {
+		if controllers.NodeNoExecuteTaint.MatchTaint(&taint) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // verifies that snr node backup equals to the actual node

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -53,7 +53,7 @@ var (
 
 	NodeNoExecuteTaint = &v1.Taint{
 		Key:    "medik8s.io/remediation",
-		Value:  "nodefencing",
+		Value:  "self-node-remediation",
 		Effect: v1.TaintEffectNoExecute,
 	}
 

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -52,8 +52,8 @@ var (
 	}
 
 	NodeNoExecuteTaint = &v1.Taint{
-		Key:    "healthcheck",
-		Value:  "medik8s",
+		Key:    "medik8s.io/remediation",
+		Value:  "nodefencing",
 		Effect: v1.TaintEffectNoExecute,
 	}
 

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -302,10 +302,6 @@ func (r *SelfNodeRemediationReconciler) remediateWithNodeDeletion(snr *v1alpha1.
 		return ctrl.Result{}, err
 	}
 
-	if err = r.addNoExecuteTaint(node); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if node.CreationTimestamp.After(snr.CreationTimestamp.Time) {
 		//this node was created after the node was reported as unhealthy
 		//we assume this is the new node after remediation and take no-op expecting the snr to be deleted
@@ -349,6 +345,10 @@ func (r *SelfNodeRemediationReconciler) remediateWithNodeDeletion(snr *v1alpha1.
 		//todo this means we only allow one remediation attempt per snr. we could add some config to
 		//snr which states max remediation attempts, and the timeout to consider a remediation failed.
 		return ctrl.Result{}, nil
+	}
+
+	if err = r.addNoExecuteTaint(node); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if !r.isNodeRebootCapable(node) {

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -86,5 +86,5 @@ spec:
       tolerations:
         - key: "medik8s.io/remediation"
           operator: "Equal"
-          value: "nodefencing"
+          value: "self-node-remediation"
           effect: "NoExecute"

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -83,3 +83,8 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: "healthcheck"
+          operator: "Equal"
+          value: "medik8s"
+          effect: "NoExecute"

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -84,7 +84,7 @@ spec:
       securityContext: {}
       terminationGracePeriodSeconds: 10
       tolerations:
-        - key: "healthcheck"
+        - key: "medik8s.io/remediation"
           operator: "Equal"
-          value: "medik8s"
+          value: "nodefencing"
           effect: "NoExecute"


### PR DESCRIPTION
- Adding a  `No Execute` taint in order to make sure after reboot the node is not running any workload - this is important so we can move this workload elsewhere even if the node does not have connectivity to the control plain.
- Once a node is healthy the taint is removed.