### PR TITLE
Create templates for both remediation strategies

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	ConfigCRName                          = "self-node-remediation-config"
-	templateCRName                        = "self-node-remediation-default-template"
 	defaultWatchdogPath                   = "/dev/watchdog"
 	defaultSafetToAssumeNodeRebootTimeout = 180
 	defaultIsSoftwareRebootEnabled        = true
@@ -149,12 +148,5 @@ func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 			SafeTimeToAssumeNodeRebootedSeconds: defaultSafetToAssumeNodeRebootTimeout,
 			IsSoftwareRebootEnabled:             defaultIsSoftwareRebootEnabled,
 		},
-	}
-}
-
-func NewDefaultRemediationTemplate() SelfNodeRemediationTemplate {
-	return SelfNodeRemediationTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: templateCRName},
-		Spec:       SelfNodeRemediationTemplateSpec{Template: SelfNodeRemediationTemplateResource{Spec: SelfNodeRemediationSpec{}}},
 	}
 }

--- a/api/v1alpha1/selfnoderemediationtemplate_types.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_types.go
@@ -20,7 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+const (
+	resourceDeletionTemplateName = "self-node-remediation-resource-deletion-template"
+	nodeDeletionTemplateName     = "self-node-remediation-node-deletion-template"
+)
+
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type SelfNodeRemediationTemplateResource struct {
@@ -65,4 +69,33 @@ type SelfNodeRemediationTemplateList struct {
 
 func init() {
 	SchemeBuilder.Register(&SelfNodeRemediationTemplate{}, &SelfNodeRemediationTemplateList{})
+}
+
+func NewRemediationTemplates() []*SelfNodeRemediationTemplate {
+	return []*SelfNodeRemediationTemplate{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resourceDeletionTemplateName,
+			},
+			Spec: SelfNodeRemediationTemplateSpec{
+				Template: SelfNodeRemediationTemplateResource{
+					Spec: SelfNodeRemediationSpec{
+						RemediationStrategy: ResourceDeletionRemediationStrategy,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeDeletionTemplateName,
+			},
+			Spec: SelfNodeRemediationTemplateSpec{
+				Template: SelfNodeRemediationTemplateResource{
+					Spec: SelfNodeRemediationSpec{
+						RemediationStrategy: NodeDeletionRemediationStrategy,
+					},
+				},
+			},
+		},
+	}
 }

--- a/main.go
+++ b/main.go
@@ -162,8 +162,8 @@ func initSelfNodeRemediationManager(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if err := newDefaultTemplateIfNotExist(mgr.GetClient()); err != nil {
-		setupLog.Error(err, "failed to create default remediation template")
+	if err := newTemplatesIfNotExist(mgr.GetClient()); err != nil {
+		setupLog.Error(err, "failed to create remediation templates")
 		os.Exit(1)
 	}
 }
@@ -311,19 +311,21 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	}
 }
 
-// newDefaultTemplateIfNotExist creates a new SelfNodeRemediationTemplate object
-func newDefaultTemplateIfNotExist(c client.Client) error {
+// newTemplatesIfNotExist creates new SelfNodeRemediationTemplate objects
+func newTemplatesIfNotExist(c client.Client) error {
 	ns, err := utils.GetDeploymentNamespace()
 	if err != nil {
 		return errors.Wrap(err, "unable to get the deployment namespace")
 	}
 
-	pprt := selfnoderemediationv1alpha1.NewDefaultRemediationTemplate()
-	pprt.SetNamespace(ns)
+	templates := selfnoderemediationv1alpha1.NewRemediationTemplates()
 
-	err = c.Create(context.Background(), &pprt, &client.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return errors.Wrap(err, "failed to create a default self node remediation template CR")
+	for _, template := range templates {
+		template.SetNamespace(ns)
+		err = c.Create(context.Background(), template, &client.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return errors.Wrap(err, "failed to create self node remediation template CR")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
For UI it's to use existing templates instead of creating them itself. So we provide templates for both remediation strategies now. The decision which one is the default is up to NHC then, by using the relevant template name in the NHC default config.