### PR TITLE
Update image build and push in CI

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -3,12 +3,8 @@ on:
   push:
     branches:
       - main
-      - 'release-*'
     tags:
       - 'v*'
-  release:
-    types:
-      - created
 
 jobs:
   push_to_registry:
@@ -32,8 +28,11 @@ jobs:
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
-      - name: Prepare Container Image
-        run: make docker-build
+      - name: Build and push operator and bundle images, using version 0.0.1, for pushes to main
+        if: ${{ github.ref_type != 'tag' }}
+        run: export VERSION=0.0.1 make docker-build bundle bundle-build docker-push bundle-push
 
-      - name: Push to Quay.io
-        run: make docker-push
+      - name: Build and push versioned operator and bundle images, for tags
+        if: ${{ github.ref_type == 'tag' }}
+        # remove leading 'v' from tag!
+        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make docker-build bundle bundle-build docker-push bundle-push

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= quay.io/medik8s/self-node-remediation-operator-bundle:$(VERSION)
 
-# Image URL to use all building/pushing image targets
+# Image URL to use building/pushing operator image
 IMG ?= quay.io/medik8s/self-node-remediation-operator:$(VERSION)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -186,9 +186,13 @@ bundle: manifests operator-sdk kustomize
 	$(KUSTOMIZE) build config/manifests | envsubst | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 
-.PHONY: bundle-build ## Build the bundle image.
-bundle-build:
+.PHONY: bundle-build
+bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: bundle-push
+bundle-push: ## Push the bundle image.
+	docker push $(BUNDLE_IMG)
 
 .PHONY: protoc ## Download protoc (protocol buffers tool needed for gRPC)
 PROTOC = $(shell pwd)/bin/proto/bin/protoc


### PR DESCRIPTION
- build and push bundle (will be used by NHC  CI)
- for merges to main use version 0.0.1 (will be used by NHC  CI)
- for tags use version from tag with stripped "v" prefix
