### PR TITLE
Fix daemonset pullspec and CSV containerImage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ bundle: manifests operator-sdk kustomize
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	sed -r -i "s|createdAt: \".*\"|createdAt: \"`date "+%Y-%m-%d %T" `\"|;" ./config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
+	sed -r -i "s|containerImage: .*|containerImage: ${IMG}|;" ./config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
 	$(KUSTOMIZE) build config/manifests | envsubst | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
 

--- a/config/default/manager_env_patch.yaml
+++ b/config/default/manager_env_patch.yaml
@@ -14,4 +14,4 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: SELF_NODE_REMEDIATION_IMAGE
-          value: quay.io/medik8s/self-node-remediation-operator:${VERSION}
+          value: ${IMG}


### PR DESCRIPTION
- in case $IMG points to another image registry or image name, the image pullspec of the daemonset wasn't updated correctly
- also update containerImage in the CSV when running `make bundle`