### PR TITLE
Fix taint removal

### DIFF
--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -106,6 +106,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:webhook
 
 	go func() {
+		defer GinkgoRecover()
 		err = mgr.Start(ctx)
 		if err != nil {
 			Expect(err).NotTo(HaveOccurred())

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -278,8 +278,6 @@ var _ = Describe("snr Controller", func() {
 				lastFoodTime = newTime
 				return false
 			}, 10*peerUpdateInterval, timeout).Should(BeTrue())
-
-			verifyNoExecuteTaintExist()
 		})
 	})
 })

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -199,10 +199,12 @@ var _ = Describe("snr Controller", func() {
 				node.Status.Conditions[0].Reason = "foo"
 				Expect(k8sClient.Client.Status().Update(context.Background(), node)).To(Succeed())
 
-				By("Verify that finalizer was removed and SNR can be deleted")
-				testNoFinalizer()
+				removeUnschedulableTaint(node)
 
 				verifyNoExecuteTaintRemoved()
+
+				By("Verify that finalizer was removed and SNR can be deleted")
+				testNoFinalizer()
 
 			})
 		})
@@ -240,10 +242,12 @@ var _ = Describe("snr Controller", func() {
 
 				verifyNodeIsSchedulable()
 
-				By("Verify that finalizer was removed and SNR can be deleted")
-				testNoFinalizer()
+				removeUnschedulableTaint(node)
 
 				verifyNoExecuteTaintRemoved()
+
+				By("Verify that finalizer was removed and SNR can be deleted")
+				testNoFinalizer()
 
 			})
 		})
@@ -419,6 +423,14 @@ func verifyTimeHasBeenRebootedExists() {
 func addUnschedulableTaint(node *v1.Node) {
 	By("Add unschedulable taint to node to simulate node controller")
 	node.Spec.Taints = append(node.Spec.Taints, *controllers.NodeUnschedulableTaint)
+	ExpectWithOffset(1, k8sClient.Client.Update(context.TODO(), node)).To(Succeed())
+}
+
+func removeUnschedulableTaint(node *v1.Node) {
+	By("Removing unschedulable taint to node to simulate node controller")
+	Expect(k8sClient.Get(context.Background(), unhealthyNodeNamespacedName, node)).To(Succeed())
+	taints, _ := utils.DeleteTaint(node.Spec.Taints, controllers.NodeUnschedulableTaint)
+	node.Spec.Taints = taints
 	ExpectWithOffset(1, k8sClient.Client.Update(context.TODO(), node)).To(Succeed())
 }
 

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -729,5 +729,6 @@ func (r *SelfNodeRemediationReconciler) removeNoExecuteTaint(node *v1.Node) erro
 		r.logger.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", NodeNoExecuteTaint.Key, "taint effect", NodeNoExecuteTaint.Effect)
 		return err
 	}
+	r.logger.Info("NoExecute taint removed")
 	return nil
 }

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -169,6 +169,7 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 	}
 
 	if r.isFencingCompleted(snr) {
+		r.logger.Info("fencing completed, cleaning up")
 		if node.Spec.Unschedulable {
 			node.Spec.Unschedulable = false
 			if err := r.Client.Update(context.Background(), node); err != nil {
@@ -192,6 +193,8 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 
 		return ctrl.Result{}, nil
 	}
+
+	r.logger.Info("fencing not completed yet, continuing remediation")
 
 	if !r.isNodeRebootCapable(node) {
 		//use err to trigger exponential backoff
@@ -470,6 +473,7 @@ func (r *SelfNodeRemediationReconciler) removeFinalizer(snr *v1alpha1.SelfNodeRe
 		r.logger.Error(err, "failed to remove finalizer from snr")
 		return err
 	}
+	r.logger.Info("finalizer removed")
 	return nil
 }
 
@@ -489,6 +493,7 @@ func (r *SelfNodeRemediationReconciler) addFinalizer(snr *v1alpha1.SelfNodeRemed
 		r.logger.Error(err, "failed to add finalizer to snr")
 		return ctrl.Result{}, err
 	}
+	r.logger.Info("finalizer added")
 	return ctrl.Result{Requeue: true}, nil
 }
 
@@ -701,6 +706,7 @@ func (r *SelfNodeRemediationReconciler) addNoExecuteTaint(node *v1.Node) error {
 		r.logger.Error(err, "Failed to add taint on node", "node name", node.Name, "taint key", NodeNoExecuteTaint.Key, "taint effect", NodeNoExecuteTaint.Effect)
 		return err
 	}
+	r.logger.Info("NoExecute taint added", "new taints", node.Spec.Taints)
 	return nil
 }
 
@@ -729,6 +735,6 @@ func (r *SelfNodeRemediationReconciler) removeNoExecuteTaint(node *v1.Node) erro
 		r.logger.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", NodeNoExecuteTaint.Key, "taint effect", NodeNoExecuteTaint.Effect)
 		return err
 	}
-	r.logger.Info("NoExecute taint removed")
+	r.logger.Info("NoExecute taint removed", "new taints", node.Spec.Taints)
 	return nil
 }

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -198,12 +198,12 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 		return ctrl.Result{}, errors.New("Node is not capable to reboot itself")
 	}
 
-	if err = r.addNoExecuteTaint(node); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if !controllerutil.ContainsFinalizer(snr, SNRFinalizer) {
 		return r.addFinalizer(snr)
+	}
+
+	if err = r.addNoExecuteTaint(node); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if !node.Spec.Unschedulable || !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
@@ -347,16 +347,16 @@ func (r *SelfNodeRemediationReconciler) remediateWithNodeDeletion(snr *v1alpha1.
 		return ctrl.Result{}, nil
 	}
 
-	if err = r.addNoExecuteTaint(node); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if !r.isNodeRebootCapable(node) {
 		return ctrl.Result{}, errors.New("Node is not capable to reboot itself")
 	}
 
 	if !controllerutil.ContainsFinalizer(snr, SNRFinalizer) {
 		return r.addFinalizer(snr)
+	}
+
+	if err = r.addNoExecuteTaint(node); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if !node.Spec.Unschedulable || !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -117,7 +117,7 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
-		MetricsBindAddress: ":8080",
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/certificates/suite_test.go
+++ b/pkg/certificates/suite_test.go
@@ -46,7 +46,7 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
-		MetricsBindAddress: ":8082",
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	var ctx context.Context

--- a/pkg/peerhealth/suite_test.go
+++ b/pkg/peerhealth/suite_test.go
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
-		MetricsBindAddress: ":8081",
+		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	var ctx context.Context


### PR DESCRIPTION
In manual tests and NHC CI the NoExecute taint isn't removed after remediation.

For debugging and fixing the issue this PR evolved over time and mainly contains these changes:
- add e2e test for the taint (didn't reproduce the issue)
- add taint after adding finalizer (didn't fix the issue)
- wait for removal of Unschedulable Taint after setting Unschedulable to false: this fixed the issue! It was a race between node-lifecycle-controller and us with removing taints

more changes:
- added logging
- fix running unit test when they break (prevent metrics port conflicts)
- use existing DeleteTaint func
- add TimeAdded to taint