### PR TITLE
Add opm target for building catalog image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,19 @@ ifeq (,$(wildcard $(OPERATOR_SDK)))
 	}
 endif
 
+.PHONY: opm
+OPM = ./bin/opm
+opm: ## Download opm locally if necessary.
+ifeq (,$(wildcard $(OPM)))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPM)) ;\
+	OS=linux && ARCH=amd64 && \
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	chmod +x $(OPM) ;\
+	}
+endif
+
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMG to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)


### PR DESCRIPTION
The Github action of #13 post PR has [failed](https://github.com/medik8s/self-node-remediation/runs/6966313937?check_suite_focus=true), due to missing target of _opm_ which is used for building a catalog image.