### PR TITLE
Remove taint and finalizer only when SNR is targeted to delete by NHC

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=self-node-remediation
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -414,7 +414,9 @@ spec:
   - SNR
   links:
   - name: Self Node Remediation
-    url: https://www.medik8s.io/
+    url: https://medik8s.io
+  - name: Source Code
+    url: https://github.com/medik8s/self-node-remediation
   maintainers:
   - email: medik8s@googlegroups.com
     name: medik8s team

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: self-node-remediation
   operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
@@ -5,8 +5,8 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: OpenShift Optional
-    containerImage: quay.io/medik8s/self-node-remediation-operator:0.0.0
-    createdAt: "2022-04-28 21:46:09"
+    containerImage: quay.io/medik8s/self-node-remediation-operator:latest
+    createdAt: "2022-06-28 14:27:16"
     description: Self Node Remediation Operator for remediate itself in case of a
       failure.
     olm.skipRange: '>=0.1.0 <0.4.0'
@@ -107,7 +107,9 @@ spec:
   - SNR
   links:
   - name: Self Node Remediation
-    url: https://www.medik8s.io/
+    url: https://medik8s.io
+  - name: Source Code
+    url: https://github.com/medik8s/self-node-remediation
   maintainers:
   - email: medik8s@googlegroups.com
     name: medik8s team

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("snr Controller", func() {
 	Context("Unhealthy node with api-server access", func() {
 		var beforeSNR time.Time
 		var remediationStrategy selfnoderemediationv1alpha1.RemediationStrategyType
-		var isDeleteSNR = true
+		var isSNRNeedsDeletion = true
 		JustBeforeEach(func() {
 			createSelfNodeRemediationPod()
 			updateIsRebootCapable("true")
@@ -150,10 +150,10 @@ var _ = Describe("snr Controller", func() {
 		})
 
 		AfterEach(func() {
-			if isDeleteSNR {
+			if isSNRNeedsDeletion {
 				deleteSNR(snr)
 			}
-			isDeleteSNR = true
+			isSNRNeedsDeletion = true
 		})
 
 		Context("NodeDeletion strategy", func() {
@@ -244,7 +244,7 @@ var _ = Describe("snr Controller", func() {
 				verifyNoExecuteTaintExist()
 
 				deleteSNR(snr)
-				isDeleteSNR = false
+				isSNRNeedsDeletion = false
 
 				verifyNodeIsSchedulable()
 

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -192,17 +192,17 @@ var _ = Describe("snr Controller", func() {
 
 				By("Update node's last hearbeat time")
 				//we simulate kubelet coming up, this is required to remove the finalizer
-				node = &v1.Node{}
-				Expect(k8sClient.Get(context.Background(), unhealthyNodeNamespacedName, node)).To(Succeed())
-				node.Status.Conditions = make([]v1.NodeCondition, 1)
-				node.Status.Conditions[0].Status = v1.ConditionTrue
-				node.Status.Conditions[0].Type = v1.NodeReady
-				node.Status.Conditions[0].LastTransitionTime = metav1.Now()
-				node.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
-				node.Status.Conditions[0].Reason = "foo"
-				Expect(k8sClient.Client.Status().Update(context.Background(), node)).To(Succeed())
+				updateNodeFunc := func(node *v1.Node) {
+					node.Status.Conditions = make([]v1.NodeCondition, 1)
+					node.Status.Conditions[0].Status = v1.ConditionTrue
+					node.Status.Conditions[0].Type = v1.NodeReady
+					node.Status.Conditions[0].LastTransitionTime = metav1.Now()
+					node.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
+					node.Status.Conditions[0].Reason = "foo"
+				}
+				eventuallyUpdateNode(updateNodeFunc, true)
 
-				removeUnschedulableTaint(node)
+				removeUnschedulableTaint()
 
 				verifyNoExecuteTaintRemoved()
 
@@ -248,7 +248,7 @@ var _ = Describe("snr Controller", func() {
 
 				verifyNodeIsSchedulable()
 
-				removeUnschedulableTaint(node)
+				removeUnschedulableTaint()
 
 				verifyNoExecuteTaintRemoved()
 
@@ -441,15 +441,13 @@ func addUnschedulableTaint(node *v1.Node) {
 	ExpectWithOffset(1, k8sClient.Client.Update(context.TODO(), node)).To(Succeed())
 }
 
-func removeUnschedulableTaint(node *v1.Node) {
+func removeUnschedulableTaint() {
 	By("Removing unschedulable taint to node to simulate node controller")
-	Eventually(func() error {
-		Expect(k8sClient.Get(context.Background(), unhealthyNodeNamespacedName, node)).To(Succeed())
+	updateNodeFund := func(node *v1.Node) {
 		taints, _ := utils.DeleteTaint(node.Spec.Taints, controllers.NodeUnschedulableTaint)
 		node.Spec.Taints = taints
-		return k8sClient.Client.Update(context.TODO(), node)
-
-	}, 5*time.Second, 250*time.Millisecond).Should(Succeed())
+	}
+	eventuallyUpdateNode(updateNodeFund, false)
 }
 
 func verifyNodeIsUnschedulable() *v1.Node {
@@ -567,4 +565,21 @@ func testNoFinalizer() {
 		//if no finalizer was set, it means we didn't start remediation process
 		return snr.Finalizers, err
 	}, 10*time.Second, 250*time.Millisecond).Should(BeEmpty())
+}
+
+func eventuallyUpdateNode(updateFunc func(*v1.Node), isStatusUpdate bool) {
+	By("Verify that node was updated successfully")
+
+	EventuallyWithOffset(1, func() error {
+		node := &v1.Node{}
+		if err := k8sClient.Client.Get(context.TODO(), unhealthyNodeNamespacedName, node); err != nil {
+			return err
+		}
+		updateFunc(node)
+		if isStatusUpdate {
+			return k8sClient.Client.Status().Update(context.TODO(), node)
+		}
+		return k8sClient.Client.Update(context.TODO(), node)
+	}, 5*time.Second, 250*time.Millisecond).Should(Succeed())
+
 }

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -158,7 +158,7 @@ func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 func (r *SelfNodeRemediationReconciler) isFencingCompleted(snr *v1alpha1.SelfNodeRemediation) bool {
-	return snr.Status.Phase != nil && *snr.Status.Phase == fencingCompletedPhase
+	return snr.Status.Phase != nil && *snr.Status.Phase == fencingCompletedPhase && snr.DeletionTimestamp != nil
 }
 
 func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alpha1.SelfNodeRemediation) (ctrl.Result, error) {

--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -115,6 +115,10 @@ var _ = Describe("Self Node Remediation E2E", func() {
 				It("should delete pods and volume attachments", func() {
 					checkPodRecreated(node, oldPodCreationTime)
 					checkVaDeleted(va)
+					//Simulate NHC trying to delete SNR
+					deleteAndWait(snr)
+					snr = nil
+
 					checkNoExecuteTaintRemoved(node)
 				})
 			})


### PR DESCRIPTION
- Removing the no Execute taint only when SNR is targeted for deletion, in order to prevent a situation where the taint is removed but the node isn't ready for workload yet.