### PR TITLE
Use ubi-micro as base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY install/ install/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+# Use ubi-micro as minimal base image to package the manager binary - https://catalog.redhat.com/software/containers/ubi8/ubi-micro/5ff3f50a831939b08d1b832a
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 
 WORKDIR /
 COPY --from=builder /workspace/install/ install/


### PR DESCRIPTION
Updating the current base image, [ubi](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#con_understanding-the-ubi-micro-images_assembly_types-of-container-images), to a newer and even smaller image , [ubi-micro](https://www.redhat.com/en/blog/introduction-ubi-micro), for building the operator (in Dockerfile).

Using smaller image minimizes the attack surface of container images, and is suitable for minimal applications.

See similar PR in NMO - https://github.com/medik8s/node-maintenance-operator/pull/37