### PR TITLE
Build index image with latest NHC + SNR for merged PRs to main

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -36,3 +36,19 @@ jobs:
         if: ${{ github.ref_type == 'tag' }}
         # remove leading 'v' from tag!
         run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build container-push
+
+      - name: Build and push index image with versioned NHC + SNR images
+        if: ${{ github.ref_type != 'tag' }}
+        run: |
+          # get script from github
+          NAME=build-nhc-snr.sh
+          curl https://raw.githubusercontent.com/medik8s/tools/main/scripts/${NAME} -o $NAME
+          chmod +x $NAME
+          
+          # set version vars
+          export NHC_VERSION=0.3.0-ci
+          export SNR_VERSION=0.4.0-ci
+          export INDEX_VERSION=4.11-ci
+          
+          # build and push images
+          ./$NAME --skip-deploy


### PR DESCRIPTION
Add build step for building and pushing versioned NHC + SNR + index images.
Similar for NHC: https://github.com/medik8s/node-healthcheck-operator/pull/107

[ECOPROJECT-877](https://issues.redhat.com//browse/ECOPROJECT-877)
