### PR TITLE
Allow watchdog grace period to reboot before "kicking" with software reboot

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -257,6 +257,8 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 		return ctrl.Result{}, err
 	}
 
+	r.logger.Info("starting to delete node resources", "node name", node.Name)
+
 	pod := &v1.Pod{}
 	for _, ns := range namespaces.Items {
 		deleteOptions.Namespace = ns.Name
@@ -284,6 +286,8 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 			}
 		}
 	}
+
+	r.logger.Info("done deleting node resources", "node name", node.Name)
 
 	fencingCompleted := fencingCompletedPhase
 	snr.Status.Phase = &fencingCompleted
@@ -415,7 +419,7 @@ func (r *SelfNodeRemediationReconciler) rebootIfNeeded(snr *v1alpha1.SelfNodeRem
 		return ctrl.Result{}, nil
 	}
 
-	return ctrl.Result{}, r.Rebooter.Reboot()
+	return r.Rebooter.Reboot()
 }
 
 // wasNodeRebooted returns true if the node assumed to been rebooted.

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -82,7 +82,7 @@ func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
 			if isHealthy := c.handleError(); !isHealthy {
 				// we have a problem on this node
 				c.config.Log.Error(err, "we are unhealthy, triggering a reboot")
-				if err := c.config.Rebooter.Reboot(); err != nil {
+				if _, err := c.config.Rebooter.Reboot(); err != nil {
 					c.config.Log.Error(err, "failed to trigger reboot")
 				}
 			} else {

--- a/pkg/watchdog/interface.go
+++ b/pkg/watchdog/interface.go
@@ -11,6 +11,8 @@ type Watchdog interface {
 	Start(ctx context.Context) error
 	// IsStarted return if the watchdog is running
 	IsStarted() bool
+	// IsRebooting return if the watchdog has already stopped feeding and currently about to reboot the node
+	IsRebooting() bool
 	// Stop stops feeding the watchdog, which results in a reboot of the node
 	Stop()
 	// GetTimeout returns the watchdog timeout when it reboots the node without feeding

--- a/pkg/watchdog/synchronized.go
+++ b/pkg/watchdog/synchronized.go
@@ -15,13 +15,13 @@ var _ Watchdog = &synchronizedWatchdog{}
 
 // synchronizedWatchdog implements the Watchdog interface with synchronized calls of the implementation specific methods
 type synchronizedWatchdog struct {
-	impl         watchdogImpl
-	timeout      time.Duration
-	isStarted    bool
-	stop         context.CancelFunc
-	mutex        sync.Mutex
-	lastFoodTime time.Time
-	log          logr.Logger
+	impl                   watchdogImpl
+	timeout                time.Duration
+	isStarted, isRebooting bool
+	stop                   context.CancelFunc
+	mutex                  sync.Mutex
+	lastFoodTime           time.Time
+	log                    logr.Logger
 }
 
 func newSynced(log logr.Logger, impl watchdogImpl) *synchronizedWatchdog {
@@ -94,6 +94,7 @@ func (swd *synchronizedWatchdog) Stop() {
 	if swd.isStarted {
 		swd.stop()
 		swd.isStarted = false
+		swd.isRebooting = true
 	}
 }
 
@@ -107,4 +108,10 @@ func (swd *synchronizedWatchdog) LastFoodTime() time.Time {
 	swd.mutex.Lock()
 	defer swd.mutex.Unlock()
 	return swd.lastFoodTime
+}
+
+func (swd *synchronizedWatchdog) IsRebooting() bool {
+	swd.mutex.Lock()
+	defer swd.mutex.Unlock()
+	return swd.isRebooting
 }


### PR DESCRIPTION
This PR suppose to solve [this](https://issues.redhat.com/browse/ECOPROJECT-879) ticket.

- At the moment a software reboot occurs immediately after watchdog is stopped so watchdog does not get a chance to reboot the node.
- We'd like on the one hand to give the watchdog some grace period to reboot (one motivation is to allow enough time to generate kernel dump ) and on the other hand to have software reboot as a backup in case watchdog reboot isn't working.