### PR TITLE
[WIP] setup psa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,12 @@ bundle-build: ## Build the bundle image.
 bundle-push: ## Push the bundle image.
 	docker push $(BUNDLE_IMG)
 
+# Generate bundle manifests and metadata, then validate generated files.
+.PHONY: bundle-k8s
+bundle-k8s: bundle
+	$(KUSTOMIZE) build config/manifests-k8s | $(OPERATOR_SDK) generate --verbose bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
+
 .PHONY: protoc ## Download protoc (protocol buffers tool needed for gRPC)
 PROTOC = $(shell pwd)/bin/proto/bin/protoc
 protoc: protoc-gen-go protoc-gen-go-grpc

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -365,9 +365,12 @@ spec:
                     memory: 110Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
               securityContext:
-                runAsNonRoot: false
+                runAsNonRoot: true
               serviceAccountName: self-node-remediation-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -370,7 +370,7 @@ spec:
                     - ALL
               priorityClassName: system-cluster-critical
               securityContext:
-                runAsNonRoot: true
+                runAsNonRoot: false
               serviceAccountName: self-node-remediation-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -142,6 +142,12 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - namespaces
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
           - nodes
           verbs:
           - create

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -19,3 +19,8 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsNonRoot: false
+        runAsNonRoot: true
       priorityClassName: system-cluster-critical
       containers:
       - command:
@@ -39,6 +39,9 @@ spec:
                 fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsNonRoot: true
+        runAsNonRoot: false
       priorityClassName: system-cluster-critical
       containers:
       - command:

--- a/config/manifests-k8s/kustomization.yaml
+++ b/config/manifests-k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../manifests
+
+patchesStrategicMerge:
+  - seccomp_patch.yaml

--- a/config/manifests-k8s/seccomp_patch.yaml
+++ b/config/manifests-k8s/seccomp_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      securityContext:
+        # Do not use SeccompProfile if your project must work on
+        # old k8s versions < 1.19 and OpenShift < 4.11
+        seccompProfile:
+          type: RuntimeDefault

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - create

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -121,6 +121,7 @@ func (r *SelfNodeRemediationReconciler) SetupWithManager(mgr ctrl.Manager) error
 //+kubebuilder:rbac:groups=self-node-remediation.medik8s.io,resources=selfnoderemediations/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=update
 
 func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.logger = r.Log.WithValues("selfnoderemediation", req.NamespacedName)

--- a/main.go
+++ b/main.go
@@ -143,9 +143,8 @@ func initSelfNodeRemediationManager(mgr manager.Manager) {
 		setupLog.Error(err, "failed to get deployed namespace from env var")
 		os.Exit(1)
 	}
-	setupLog.Info("[DEBUG] 0 about to create label setter")
+
 	labelSetter := utils.NewNsLabelSetter(ns, mgr.GetClient(), ctrl.Log.WithName("nameSpaceLabelSetter"))
-	setupLog.Info("[DEBUG] 1 label setter created")
 	if err := mgr.Add(labelSetter); err != nil {
 		setupLog.Error(err, "failed to set Pod Security Access labels on namespace")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -144,6 +144,12 @@ func initSelfNodeRemediationManager(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
+	labelSetter := utils.NewNsLabelSetter(ns, mgr.GetClient(), ctrl.Log.WithName("nameSpaceLabelSetter"))
+	if err := mgr.Add(labelSetter); err != nil {
+		setupLog.Error(err, "failed to set Pod Security Access labels on namespace")
+		os.Exit(1)
+	}
+
 	if err := (&controllers.SelfNodeRemediationConfigReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("SelfNodeRemediationConfig"),

--- a/main.go
+++ b/main.go
@@ -143,8 +143,9 @@ func initSelfNodeRemediationManager(mgr manager.Manager) {
 		setupLog.Error(err, "failed to get deployed namespace from env var")
 		os.Exit(1)
 	}
-
+	setupLog.Info("[DEBUG] 0 about to create label setter")
 	labelSetter := utils.NewNsLabelSetter(ns, mgr.GetClient(), ctrl.Log.WithName("nameSpaceLabelSetter"))
+	setupLog.Info("[DEBUG] 1 label setter created")
 	if err := mgr.Add(labelSetter); err != nil {
 		setupLog.Error(err, "failed to set Pod Security Access labels on namespace")
 		os.Exit(1)

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -43,28 +43,23 @@ func NewNsLabelSetter(nsName string, client client.Client, log logr.Logger) *lab
 }
 
 func (ls *labelSetter) Start(ctx context.Context) error {
-	ls.log.Info("[DEBUG] 2 label setter triggered !")
 	return ls.setPsaLabels()
 }
 
 func (ls *labelSetter) setPsaLabels() error {
-
 	ns := &v1.Namespace{}
 	if err := ls.k8sClient.Get(context.Background(), client.ObjectKey{Name: ls.nsName}, ns); err != nil {
-		ls.log.Info("[DEBUG] 2.1 label setter terminated")
 		ls.log.Error(err, "failed to fetch namespace")
 		return err
 	}
-	ls.log.Info("[DEBUG] 2.2 label setter fetched namespace")
 
 	ns.Labels[psaPrivileges] = "privileged"
 	ns.Labels[psaLabelSync] = "false"
 
 	if err := ls.k8sClient.Update(context.Background(), ns); err != nil {
-		ls.log.Info("[DEBUG] 2.3 label setter terminated")
 		ls.log.Error(err, "failed to update namespace with pod security access labels")
 		return err
 	}
-	ls.log.Info("[DEBUG] 2.4 label setter updated namespace")
+
 	return nil
 }

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -43,23 +43,28 @@ func NewNsLabelSetter(nsName string, client client.Client, log logr.Logger) *lab
 }
 
 func (ls *labelSetter) Start(ctx context.Context) error {
+	ls.log.Info("[DEBUG] 2 label setter triggered !")
 	return ls.setPsaLabels()
 }
 
 func (ls *labelSetter) setPsaLabels() error {
+
 	ns := &v1.Namespace{}
 	if err := ls.k8sClient.Get(context.Background(), client.ObjectKey{Name: ls.nsName}, ns); err != nil {
+		ls.log.Info("[DEBUG] 2.1 label setter terminated")
 		ls.log.Error(err, "failed to fetch namespace")
 		return err
 	}
+	ls.log.Info("[DEBUG] 2.2 label setter fetched namespace")
 
 	ns.Labels[psaPrivileges] = "privileged"
 	ns.Labels[psaLabelSync] = "false"
 
 	if err := ls.k8sClient.Update(context.Background(), ns); err != nil {
+		ls.log.Info("[DEBUG] 2.3 label setter terminated")
 		ls.log.Error(err, "failed to update namespace with pod security access labels")
 		return err
 	}
-
+	ls.log.Info("[DEBUG] 2.4 label setter updated namespace")
 	return nil
 }

--- a/pkg/utils/namespaces.go
+++ b/pkg/utils/namespaces.go
@@ -1,8 +1,21 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	//psa labels
+	psaPrivileges = "pod-security.kubernetes.io/enforce"
+	psaLabelSync  = "security.openshift.io/scc.podSecurityLabelSync"
 )
 
 // GetDeploymentNamespace returns the Namespace this operator is deployed on.
@@ -17,4 +30,36 @@ func GetDeploymentNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", deployNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+type labelSetter struct {
+	nsName    string
+	k8sClient client.Client
+	log       logr.Logger
+}
+
+func NewNsLabelSetter(nsName string, client client.Client, log logr.Logger) *labelSetter {
+	return &labelSetter{k8sClient: client, nsName: nsName, log: log}
+}
+
+func (ls *labelSetter) Start(ctx context.Context) error {
+	return ls.setPsaLabels()
+}
+
+func (ls *labelSetter) setPsaLabels() error {
+	ns := &v1.Namespace{}
+	if err := ls.k8sClient.Get(context.Background(), client.ObjectKey{Name: ls.nsName}, ns); err != nil {
+		ls.log.Error(err, "failed to fetch namespace")
+		return err
+	}
+
+	ns.Labels[psaPrivileges] = "privileged"
+	ns.Labels[psaLabelSync] = "false"
+
+	if err := ls.k8sClient.Update(context.Background(), ns); err != nil {
+		ls.log.Error(err, "failed to update namespace with pod security access labels")
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR is related to [ECOPROJECT-812](https://issues.redhat.com//browse/ECOPROJECT-812) 

When SNR starts it'll set `"pod-security.kubernetes.io/enforce"=privileged` and `"security.openshift.io/scc.podSecurityLabelSync"=false` labels on the namespace.

- `pod-security.kubernetes.io/enforce` enables the creation of the snr agent pod (which requires root permissions).
- `security.openshift.io/scc.podSecurityLabelSync` disables the label syncer on that namespace in order to make sure the previous label isn't removed. 

I've done the following testes
- I've made sure snr can't run the agents pods without root permissions (tested on OCP)
- I've made sure that a pod with root permissions can be installed when the above labels are set on the ns (tested on 1.25 k8s  cluster created with Kind)
-  I've made sure that a pod with root permissions can't be installed without `pod-security.kubernetes.io/enforce` label, or with restricted value(tested on 1.25 k8s  cluster created with Kind)