### PR TITLE
Update scorecard version to fix olm-status-descriptors-test bug

### DIFF
--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -48,7 +48,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -58,7 +58,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-status-descriptors-test

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-crds-have-resources-test
@@ -34,7 +34,7 @@
     entrypoint:
     - scorecard-test
     - olm-spec-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-spec-descriptors-test
@@ -44,7 +44,7 @@
     entrypoint:
     - scorecard-test
     - olm-status-descriptors
-    image: quay.io/operator-framework/scorecard-test:v1.5.0
+    image: quay.io/operator-framework/scorecard-test:v1.25.2
     labels:
       suite: olm
       test: olm-status-descriptors-test


### PR DESCRIPTION
SNR's scorecard test, `olm-status-descriptors-test `,  [has failed before](https://github.com/operator-framework/operator-sdk/issues/5548) and in order to use the [new fix](https://github.com/operator-framework/operator-sdk/pull/5948) we need to update the scorecard test version to the latest version -[`v1.25.2`](https://github.com/operator-framework/operator-sdk/releases).

[ECOPROJECT-1070](https://issues.redhat.com//browse/ECOPROJECT-1070)