### PR TITLE
Bug Fix ECOPROJECT-1028

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,9 +56,9 @@ import (
 )
 
 const (
-	nodeNameEnvVar        = "MY_NODE_NAME"
+	nodeNameEnvVar            = "MY_NODE_NAME"
 	peerHealthDefaultPort     = 30001
-	maxTimeForNoPeersResponse = 60 * time.Second
+	maxTimeForNoPeersResponse = 30 * time.Second
 )
 
 var (
@@ -277,8 +277,8 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	timeToAssumeNodeRebooted := getDurEnvVarOrDie("TIME_TO_ASSUME_NODE_REBOOTED")
 
 	// but the reboot time needs be at least the time we know we need for determining a node issue and trigger the reboot!
-	// 1. time for determing node issue
-	minTimeToAssumeNodeRebooted := (apiCheckInterval + apiServerTimeout) * time.Duration(maxErrorThreshold)
+	// 1. time for determine node issue
+	minTimeToAssumeNodeRebooted := (apiCheckInterval + apiServerTimeout) * time.Duration(maxErrorThreshold) + maxTimeForNoPeersResponse
 	// 2. time for asking peers (10% batches + 1st smaller batch)
 	minTimeToAssumeNodeRebooted += (10 + 1) * (peerDialTimeout + peerRequestTimeout)
 	// 3. watchdog timeout

--- a/main.go
+++ b/main.go
@@ -57,7 +57,8 @@ import (
 
 const (
 	nodeNameEnvVar        = "MY_NODE_NAME"
-	peerHealthDefaultPort = 30001
+	peerHealthDefaultPort     = 30001
+	maxTimeForNoPeersResponse = 60 * time.Second
 )
 
 var (
@@ -244,18 +245,19 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	certReader := certificates.NewSecretCertStorage(mgr.GetClient(), ctrl.Log.WithName("SecretCertStorage"), ns)
 
 	apiConnectivityCheckConfig := &apicheck.ApiConnectivityCheckConfig{
-		Log:                ctrl.Log.WithName("api-check"),
-		MyNodeName:         myNodeName,
-		CheckInterval:      apiCheckInterval,
-		MaxErrorsThreshold: maxErrorThreshold,
-		Peers:              myPeers,
-		Rebooter:           rebooter,
-		Cfg:                mgr.GetConfig(),
-		CertReader:         certReader,
-		ApiServerTimeout:   apiServerTimeout,
-		PeerDialTimeout:    peerDialTimeout,
-		PeerRequestTimeout: peerRequestTimeout,
-		PeerHealthPort:     peerHealthDefaultPort,
+		Log:                       ctrl.Log.WithName("api-check"),
+		MyNodeName:                myNodeName,
+		CheckInterval:             apiCheckInterval,
+		MaxErrorsThreshold:        maxErrorThreshold,
+		Peers:                     myPeers,
+		Rebooter:                  rebooter,
+		Cfg:                       mgr.GetConfig(),
+		CertReader:                certReader,
+		ApiServerTimeout:          apiServerTimeout,
+		PeerDialTimeout:           peerDialTimeout,
+		PeerRequestTimeout:        peerRequestTimeout,
+		PeerHealthPort:            peerHealthDefaultPort,
+		MaxTimeForNoPeersResponse: maxTimeForNoPeersResponse,
 	}
 
 	controlPlaneManager := controlplane.NewManager(myNodeName, mgr.GetClient())

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -168,6 +168,7 @@ func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {
 		}
 
 		if apiErrorsResponses > 0 {
+			c.config.Log.Info("Peer can't access the api-server")
 			apiErrorsResponsesSum += apiErrorsResponses
 			//todo consider using [m|n]hc.spec.maxUnhealthy instead of 50%
 			if apiErrorsResponsesSum > nrAllNodes/2 { //already reached more than 50% of the nodes and all of them returned api error

--- a/pkg/peers/response.go
+++ b/pkg/peers/response.go
@@ -8,10 +8,11 @@ type Response struct {
 type reason string
 
 const (
-	HealthyBecauseCRNotFound                   reason = "CR Not found, node is considered healthy"
-	HealthyBecauseErrorsThresholdNotReached    reason = "Errors number hasn't reached threshold not querying peers yet, node is considered healthy"
-	HealthyBecauseNoPeersWereFound             reason = "No Peers where found, node is considered healthy"
-	HealthyBecauseMostPeersCantAccessAPIServer reason = "Most peers couldn't access API server, node is considered healthy"
+	HealthyBecauseCRNotFound                           reason = "CR Not found, node is considered healthy"
+	HealthyBecauseErrorsThresholdNotReached            reason = "Errors number hasn't reached threshold not querying peers yet, node is considered healthy"
+	HealthyBecauseNoPeersResponseNotReachedMaxAttempts reason = "No response from peer hasn't passed the non responsive time threshold so still considered healthy"
+	HealthyBecauseNoPeersWereFound                     reason = "No Peers where found, node is considered healthy"
+	HealthyBecauseMostPeersCantAccessAPIServer         reason = "Most peers couldn't access API server, node is considered healthy"
 
 	UnHealthyBecausePeersResponse  reason = "Node is reported unhealthy by it's peers"
 	UnHealthyBecauseNodeIsIsolated reason = "Node is isolated, node is considered unhealthy"


### PR DESCRIPTION
[ECOPROJECT-1028](https://issues.redhat.com//browse/ECOPROJECT-1028) bug fix.
Adding a grace time before deciding that a worker peer is unresponsive. 
This way node will not assume it's isolated due to to short network/communication issue.

I've managed to recreate the bug and test the fix on 4.12 OCP