### PR TITLE
Update build tool versions in SNR 0.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONTROLLER_GEN_VERSION = v0.8.0
 ENVTEST_K8S_VERSION = 1.23
 
 # versions at https://github.com/operator-framework/operator-sdk/releases
-OPERATOR_SDK_VERSION = v1.19.0
+OPERATOR_SDK_VERSION = v1.25.3
 
 # versions at https://github.com/operator-framework/operator-registry/releases
 OPM_VERSION = v1.26.2

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ ENVTEST_K8S_VERSION = 1.23
 # versions at https://github.com/operator-framework/operator-sdk/releases
 OPERATOR_SDK_VERSION = v1.19.0
 
+# versions at https://github.com/operator-framework/operator-registry/releases
+OPM_VERSION = v1.26.2
 
 # SHELL defines bash so all the inline scripts here will work as expected.
 SHELL := /bin/bash
@@ -266,14 +268,16 @@ ifeq (,$(wildcard $(OPERATOR_SDK)))
 endif
 
 .PHONY: opm
-OPM = ./bin/opm
+OPM_BIN_FOLDER = ./bin/opm
+OPM = $(OPM_BIN_FOLDER)/$(OPM_VERSION)/opm
 opm: ## Download opm locally if necessary.
 ifeq (,$(wildcard $(OPM)))
 	@{ \
 	set -e ;\
+	rm -rf $(OPM_BIN_FOLDER) ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=linux && ARCH=amd64 && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# versions at  https://github.com/kubernetes-sigs/controller-tools/tags
+CONTROLLER_GEN_VERSION = v0.8.0
+
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.23
+
+# versions at https://github.com/operator-framework/operator-sdk/releases
+OPERATOR_SDK_VERSION = v1.19.0
+
+
 # SHELL defines bash so all the inline scripts here will work as expected.
 SHELL := /bin/bash
 
@@ -65,9 +75,6 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-operator-catalog:$(IMAGE_TAG)
 
 # Image URL to use all building/pushing image targets
 export IMG ?= $(IMAGE_TAG_BASE)-operator:$(IMAGE_TAG)
-
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
 
 # Get the currently used golang install path (in GOPATH/bin.old, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -168,7 +175,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete -f -
 
-CONTROLLER_GEN_VERSION = v0.8.0
+
 CONTROLLER_GEN_BIN_FOLDER = $(shell pwd)/bin/controller-gen
 CONTROLLER_GEN = $(CONTROLLER_GEN_BIN_FOLDER)/$(CONTROLLER_GEN_VERSION)/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
@@ -244,7 +251,6 @@ e2e-test:
 	go test ./e2e -ginkgo.v -ginkgo.progress -test.v -timeout 60m -count=1
 
 .PHONY: operator-sdk
-OPERATOR_SDK_VERSION = v1.19.0
 OPERATOR_SDK_BIN_FOLDER = ./bin/operator-sdk
 OPERATOR_SDK = $(OPERATOR_SDK_BIN_FOLDER)/$(OPERATOR_SDK_VERSION)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ OPERATOR_SDK_VERSION = v1.19.0
 # versions at https://github.com/operator-framework/operator-registry/releases
 OPM_VERSION = v1.26.2
 
+# versions at https://github.com/kubernetes-sigs/kustomize/releases
+KUSTOMIZE_VERSION = v4.5.7
+
 # SHELL defines bash so all the inline scripts here will work as expected.
 SHELL := /bin/bash
 
@@ -189,9 +192,16 @@ ifeq (,$(wildcard $(CONTROLLER_GEN)))
 	}
 endif
 
-KUSTOMIZE = $(shell pwd)/bin/kustomize
+KUSTOMIZE_BIN_FOLDER = $(shell pwd)/bin/kustomize
+KUSTOMIZE = $(KUSTOMIZE_BIN_FOLDER)/$(KUSTOMIZE_VERSION)/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
+ifeq (,$(wildcard $(KUSTOMIZE)))
+	@{ \
+	rm -rf $(KUSTOMIZE_BIN_FOLDER) ;\
+	mkdir -p $(dir $(KUSTOMIZE)) ;\
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@${KUSTOMIZE_VERSION}) ;\
+	}
+endif
 
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=self-node-remediation
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.18.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.3
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     description: Self Node Remediation Operator for remediate itself in case of a
       failure.
     olm.skipRange: '>=0.4.0 <0.5.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.25.3
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/self-node-remediation
     support: Medik8s

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: self-node-remediation
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
As part of [ECOPROJECT-926](https://issues.redhat.com//browse/ECOPROJECT-926)
- aligned versions to the top of make file
- operator sdk updated from 1.19 to 1.25.3
- kustomize updated from 4.5.4 to 4.5.7 & and modified not to cache the old version
- opm updated from 1.25 to 1.26.2 & and modified not to cache the old version