### PR TITLE
Watchdog init logic

### DIFF
--- a/controllers/selfnoderemediation_controller_test.go
+++ b/controllers/selfnoderemediation_controller_test.go
@@ -2,23 +2,24 @@ package controllers_test
 
 import (
 	"context"
-	"github.com/medik8s/self-node-remediation/controllers"
-	"github.com/medik8s/self-node-remediation/pkg/utils"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	selfnoderemediationv1alpha1 "github.com/medik8s/self-node-remediation/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/medik8s/self-node-remediation/controllers"
+	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 const (

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -151,7 +151,7 @@ var _ = BeforeSuite(func() {
 	peerNode = getNode(peerNodeName)
 	Expect(k8sClient.Create(context.Background(), peerNode)).To(Succeed(), "failed to create peer node")
 
-	dummyDog, err = watchdog.NewFake(ctrl.Log.WithName("fake watchdog"))
+	dummyDog, err = watchdog.NewFake(true)
 	Expect(err).ToNot(HaveOccurred())
 	err = k8sManager.Add(dummyDog)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/reboot/rebooter.go
+++ b/pkg/reboot/rebooter.go
@@ -36,6 +36,9 @@ func (r *WatchdogRebooter) Reboot() error {
 		r.log.Info("no watchdog is present on this host, trying software reboot")
 		//we couldn't init a watchdog so far but requested to be rebooted. we issue a software reboot
 		return r.softwareReboot()
+	} else if r.wd.Status() == watchdog.Malfunction {
+		r.log.Info("watchdog is malfunctioning on this host, trying software reboot")
+		return r.softwareReboot()
 	}
 
 	//Watch dog is rebooting, wait to make sure watchdog is rebooting properly otherwise intervene with software reboot

--- a/pkg/reboot/rebooter_test.go
+++ b/pkg/reboot/rebooter_test.go
@@ -1,0 +1,64 @@
+package reboot
+
+import (
+	"context"
+	"os"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/medik8s/self-node-remediation/pkg/utils"
+	"github.com/medik8s/self-node-remediation/pkg/watchdog"
+)
+
+var isSoftwareRebootCalled bool
+
+var _ = Describe("Watchdog tests", func() {
+	var rebooter *watchdogRebooter
+
+	Context("Crash on start", func() {
+		BeforeEach(func() {
+			wd, _ := watchdog.NewFake(false)
+			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot}
+
+		})
+
+		AfterEach(func() {
+			isSoftwareRebootCalled = false
+		})
+
+		Context("Software reboot is disabled", func() {
+			It("watchdog should not start", func() {
+				wd := rebooter.wd
+				err := wd.Start(context.TODO())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to start watchdog, can't default to software reboot"))
+				Expect(wd.Status()).To(Equal(watchdog.Disarmed))
+			})
+		})
+
+		Context("Software reboot is enabled", func() {
+			BeforeEach(func() {
+				_ = os.Setenv(utils.IsSoftwareRebootEnabledEnvVar, "true")
+			})
+			It("should return healthy", func() {
+				wd := rebooter.wd
+				err := wd.Start(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(wd.Status()).To(Equal(watchdog.Malfunction))
+				//Verify reboot goes as expected
+				Expect(rebooter.Reboot()).ToNot(HaveOccurred())
+				Expect(isSoftwareRebootCalled).To(BeTrue())
+			})
+		})
+
+	})
+
+})
+
+func fakeSoftwareReboot() error {
+	isSoftwareRebootCalled = true
+	return nil
+}

--- a/pkg/reboot/rebooter_test.go
+++ b/pkg/reboot/rebooter_test.go
@@ -15,10 +15,10 @@ import (
 
 var isSoftwareRebootCalled bool
 
-var _ = Describe("Watchdog tests", func() {
+var _ = Describe("Rebooter tests", func() {
 	var rebooter *watchdogRebooter
 
-	Context("Crash on start", func() {
+	Describe("Crash on start", func() {
 		BeforeEach(func() {
 			wd, _ := watchdog.NewFake(false)
 			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot}

--- a/pkg/reboot/suite_test.go
+++ b/pkg/reboot/suite_test.go
@@ -1,0 +1,25 @@
+package reboot
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+func TestWatchdog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Rebooter Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+
+}, 60)
+
+var _ = AfterSuite(func() {
+
+})

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -13,7 +13,7 @@ import (
 const (
 	// IsRebootCapableAnnotation value is the key name for the node's annotation that will determine if node is reboot capable
 	IsRebootCapableAnnotation     = "is-reboot-capable.self-node-remediation.medik8s.io"
-	isSoftwareRebootEnabledEnvVar = "IS_SOFTWARE_REBOOT_ENABLED"
+	IsSoftwareRebootEnabledEnvVar = "IS_SOFTWARE_REBOOT_ENABLED"
 )
 
 // UpdateNodeWithIsRebootCapableAnnotation updates the is-reboot-capable node annotation to be true if any kind
@@ -34,7 +34,6 @@ func UpdateNodeWithIsRebootCapableAnnotation(watchdogInitiated bool, nodeName st
 		return err
 	}
 
-
 	if node.Annotations == nil {
 		node.Annotations = map[string]string{}
 	}
@@ -53,7 +52,7 @@ func UpdateNodeWithIsRebootCapableAnnotation(watchdogInitiated bool, nodeName st
 }
 
 func IsSoftwareRebootEnabled() (bool, error) {
-	softwareRebootEnabledEnv := os.Getenv(isSoftwareRebootEnabledEnvVar)
+	softwareRebootEnabledEnv := os.Getenv(IsSoftwareRebootEnabledEnvVar)
 	softwareRebootEnabled, err := strconv.ParseBool(softwareRebootEnabledEnv)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to convert IS_SOFTWARE_REBOOT_ENABLED env valueto boolean. value is: %s", softwareRebootEnabledEnv)

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -55,7 +55,7 @@ func IsSoftwareRebootEnabled() (bool, error) {
 	softwareRebootEnabledEnv := os.Getenv(IsSoftwareRebootEnabledEnvVar)
 	softwareRebootEnabled, err := strconv.ParseBool(softwareRebootEnabledEnv)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to convert IS_SOFTWARE_REBOOT_ENABLED env valueto boolean. value is: %s", softwareRebootEnabledEnv)
+		return false, errors.Wrapf(err, "failed to convert IS_SOFTWARE_REBOOT_ENABLED env value to boolean. value is: %s", softwareRebootEnabledEnv)
 	}
 	return softwareRebootEnabled, nil
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	// IsRebootCapableAnnotation value is the key name for the node's annotation that will determine if node is reboot capable
-	IsRebootCapableAnnotation = "is-reboot-capable.self-node-remediation.medik8s.io"
+	IsRebootCapableAnnotation     = "is-reboot-capable.self-node-remediation.medik8s.io"
+	isSoftwareRebootEnabledEnvVar = "IS_SOFTWARE_REBOOT_ENABLED"
 )
 
 // UpdateNodeWithIsRebootCapableAnnotation updates the is-reboot-capable node annotation to be true if any kind
@@ -27,11 +28,12 @@ func UpdateNodeWithIsRebootCapableAnnotation(watchdogInitiated bool, nodeName st
 		return errors.Wrapf(err, "failed to retrieve my node: "+nodeName)
 	}
 
-	softwareRebootEnabledEnv := os.Getenv("IS_SOFTWARE_REBOOT_ENABLED")
-	softwareRebootEnabled, err := strconv.ParseBool(softwareRebootEnabledEnv)
-	if err != nil {
-		return errors.Wrapf(err, "failed to convert IS_SOFTWARE_REBOOT_ENABLED env valueto boolean. value is: %s", softwareRebootEnabledEnv)
+	var softwareRebootEnabled bool
+	var err error
+	if softwareRebootEnabled, err = IsSoftwareRebootEnabled(); err != nil {
+		return err
 	}
+
 
 	if node.Annotations == nil {
 		node.Annotations = map[string]string{}
@@ -48,4 +50,13 @@ func UpdateNodeWithIsRebootCapableAnnotation(watchdogInitiated bool, nodeName st
 	}
 
 	return nil
+}
+
+func IsSoftwareRebootEnabled() (bool, error) {
+	softwareRebootEnabledEnv := os.Getenv(isSoftwareRebootEnabledEnvVar)
+	softwareRebootEnabled, err := strconv.ParseBool(softwareRebootEnabledEnv)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to convert IS_SOFTWARE_REBOOT_ENABLED env valueto boolean. value is: %s", softwareRebootEnabledEnv)
+	}
+	return softwareRebootEnabled, nil
 }

--- a/pkg/watchdog/synchronized.go
+++ b/pkg/watchdog/synchronized.go
@@ -49,6 +49,7 @@ func (swd *synchronizedWatchdog) Start(ctx context.Context) error {
 	timeout, err := swd.impl.start()
 	if err != nil {
 		// TODO or return the error and fail the pod's start?
+
 		return nil
 	}
 	swd.timeout = *timeout

--- a/pkg/watchdog/synchronized.go
+++ b/pkg/watchdog/synchronized.go
@@ -2,11 +2,12 @@ package watchdog
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/medik8s/self-node-remediation/pkg/utils"
+	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -17,6 +18,7 @@ const (
 	Disarmed watchdogStatus = iota
 	Armed
 	Triggered
+	Malfunction
 )
 
 type watchdogStatus uint8
@@ -46,11 +48,16 @@ func (swd *synchronizedWatchdog) Start(ctx context.Context) error {
 	if swd.status != Disarmed {
 		return errors.New("watchdog was started more than once. This is likely to be caused by being added to a manager multiple times")
 	}
-	timeout, err := swd.impl.start()
-	if err != nil {
-		// TODO or return the error and fail the pod's start?
-
-		return nil
+	timeout, startErr := swd.impl.start()
+	if startErr != nil {
+		//In case can't use software reboot return an error
+		if isSoftwareRebootEnabled, err := utils.IsSoftwareRebootEnabled(); err != nil || !isSoftwareRebootEnabled {
+			return errors.Wrapf(err, "failed to start watchdog, can't default to software reboot")
+		} else {
+			swd.status = Malfunction
+			swd.log.Error(startErr, "error while starting watchdog, reverting to software reboot")
+			return nil
+		}
 	}
 	swd.timeout = *timeout
 	swd.status = Armed


### PR DESCRIPTION
Fix for [ECOPROJECT-483](https://issues.redhat.com//browse/ECOPROJECT-483) .

Previously the use case where WD failed to start was ignored - which might have ultimately caused a failure to fence/remediate a failed node later on.

Now, in case software reboot **isn't enabled** SNR will fail to initialize.
In case watchdog failed to start and software reboot **is enabled** we will failover to software reboot.