### PR TITLE
Extend some test wait times

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -536,7 +536,7 @@ func checkNoReboot(node *v1.Node, oldBootTime *time.Time) {
 		}
 		logger.Info("boot time", "new", newBootTime)
 		return *newBootTime
-	}, 1*time.Minute, 10*time.Second).Should(BeTemporally("==", *oldBootTime))
+	}, 5*time.Minute, 10*time.Second).Should(BeTemporally("==", *oldBootTime))
 }
 
 func checkSnrLogs(node *v1.Node, expected []string) {

--- a/e2e/utils/pod.go
+++ b/e2e/utils/pod.go
@@ -38,5 +38,5 @@ func WaitForPodReady(c client.Client, pod *corev1.Pod) {
 			}
 		}
 		return corev1.ConditionUnknown
-	}, 4*time.Minute, 10*time.Second).Should(Equal(corev1.ConditionTrue), "pod did not get ready in time")
+	}, 15*time.Minute, 10*time.Second).Should(Equal(corev1.ConditionTrue), "pod did not get ready in time")
 }


### PR DESCRIPTION
I've noted that sometimes tests fails due to timeouts waiting for pods to start / waiting for pods to be available.
I see different behavior on my own cluster (rarely fails) and also during different times of day - I assume it has to do with resource usage.
Extending the test times which are prone to cause e2e tests fail in order to improve tests stability.