### PR TITLE
Fix flaky unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,9 @@ ENVTEST_ASSETS_DIR = ${BIN_ASSETS_DIR}/setup-envtest
 ENVTEST = $(shell pwd)/bin/setup-envtest
 
 test: envtest manifests generate fmt vet ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/testbin)" go test ./api/... ./controllers/... ./pkg/... -coverprofile cover.out -v
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/testbin)" \
+		KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT="60s"\
+		go test ./api/... ./controllers/... ./pkg/... -coverprofile cover.out -v
 
 ##@ Build
 

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -107,7 +107,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:webhook
 
 	var ctx context.Context
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -46,7 +46,6 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
-var ctx context.Context
 var cancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +59,6 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
-
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
@@ -71,7 +68,8 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
@@ -108,12 +106,12 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:webhook
 
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.TODO())
 	go func() {
 		defer GinkgoRecover()
 		err = mgr.Start(ctx)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(err).NotTo(HaveOccurred())
 	}()
 
 	// wait for the webhook server to get ready

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf
 	github.com/openshift/machine-config-operator v0.0.1-0.20201023110058-6c8bd9b2915c
 	github.com/pkg/errors v0.9.1
+	go.uber.org/zap v1.21.0
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
@@ -74,7 +75,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/pkg/peerhealth/client_server_test.go
+++ b/pkg/peerhealth/client_server_test.go
@@ -7,6 +7,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -22,6 +24,17 @@ var _ = Describe("Checking health using grpc client and server", func() {
 	var phClient *Client
 
 	BeforeEach(func() {
+
+		By("creating test node")
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+		err := k8sClient.Create(context.Background(), node)
+		if !errors.IsAlreadyExists(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		By("Creating certificates")
 		caPem, certPem, keyPem, err := certificates.CreateCerts()

--- a/pkg/peerhealth/suite_test.go
+++ b/pkg/peerhealth/suite_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -62,13 +60,6 @@ var _ = BeforeSuite(func() {
 		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
-	var ctx context.Context
-	ctx, cancelFunc = context.WithCancel(ctrl.SetupSignalHandler())
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	}()
 
 	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
@@ -82,13 +73,13 @@ var _ = BeforeSuite(func() {
 	err = pprr.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	By("creating test node")
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nodeName,
-		},
-	}
-	Expect(k8sClient.Create(context.Background(), node)).ToNot(HaveOccurred())
+	var ctx context.Context
+	ctx, cancelFunc = context.WithCancel(ctrl.SetupSignalHandler())
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
 
 }, 60)
 

--- a/pkg/peerhealth/suite_test.go
+++ b/pkg/peerhealth/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -60,10 +61,13 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
+	gracefulShutdown := 0 * time.Second
+	Expect(err).ToNot(HaveOccurred())
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
-		LeaderElection:     false,
-		MetricsBindAddress: "0",
+		Scheme:                  scheme.Scheme,
+		LeaderElection:          false,
+		MetricsBindAddress:      "0",
+		GracefulShutdownTimeout: &gracefulShutdown,
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -92,6 +96,5 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancelFunc()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/pkg/peerhealth/suite_test.go
+++ b/pkg/peerhealth/suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -37,7 +38,11 @@ var pprr *controllers.SelfNodeRemediationReconciler
 var cancelFunc context.CancelFunc
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
+	}
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseFlagOptions(&opts)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -57,6 +62,7 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
+		LeaderElection:     false,
 		MetricsBindAddress: "0",
 	})
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Investigate flaky unit test.

```
Failure [20.009 seconds]
[AfterSuite] AfterSuite 
/go/src/github.com/medik8s/self-node-remediation/pkg/peerhealth/suite_test.go:95
  Unexpected error:
      <errors.aggregate | len:1, cap:1>: [
          <*errors.errorString | 0xc00018d180>{
              s: "timeout waiting for process kube-apiserver to stop",
          },
      ]
      timeout waiting for process kube-apiserver to stop
  occurred
  /go/src/github.com/medik8s/self-node-remediation/pkg/peerhealth/suite_test.go:99
```

Happens sometimes in OpenshiftCI, e.g. https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/medik8s_self-node-remediation/49/pull-ci-medik8s-self-node-remediation-main-4.13-test/1612741423029817344

Happens more often in github workflow of NHC, e.g. https://github.com/medik8s/node-healthcheck-operator/actions/runs/3885493260/jobs/6629439227

Couldn't reproduce locally yet...

**Solution**
Cleaning up some test code and fixing small issues didn't resolve the flaky tests. In the end I found how to increase the timeout (default 20s) we are running into and I needed to disabe the graceful shutdown. See last commit.