### PR TITLE
Add out of service taint remediation

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	ResourceDeletionRemediationStrategy = RemediationStrategyType("ResourceDeletion")
+	ResourceDeletionRemediationStrategy  = RemediationStrategyType("ResourceDeletion")
+	OutOfServiceTaintRemediationStrategy = RemediationStrategyType("OutOfServiceTaint")
 	// SnrConditionProcessing is the condition type used to signal NHC the remediation status
 	SnrConditionProcessing = "Processing"
 )
@@ -33,11 +34,13 @@ type RemediationStrategyType string
 
 // SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
 type SelfNodeRemediationSpec struct {
-	//RemediationStrategy is the remediation method for unhealthy nodes
-	//currently "NodeDeletion" is deprecated and "ResourceDeletion" will always happen, regardless of which strategy is selected
-	//it will iterate over all pods and volume attachments related to the unhealthy node and delete them
+	//RemediationStrategy is the remediation method for unhealthy nodes.
+	//Currently "NodeDeletion" is deprecated and it could be either "ResourceDeletion" or "OutOfServiceTaint".
+	//The first will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
+	//The latter will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+	//that enables automatic deletion of pv-attached pods on failed nodes.
 	// +kubebuilder:default:="ResourceDeletion"
-	// +kubebuilder:validation:Enum=ResourceDeletion
+	// +kubebuilder:validation:Enum=ResourceDeletion;OutOfServiceTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -43,12 +43,15 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes currently "NodeDeletion" is deprecated and "ResourceDeletion"
-                  will always happen, regardless of which strategy is selected it
-                  will iterate over all pods and volume attachments related to the
-                  unhealthy node and delete them
+                  nodes. Currently "NodeDeletion" is deprecated and it could be either
+                  "ResourceDeletion" or "OutOfServiceTaint". The first will iterate
+                  over all pods and VolumeAttachment related to the unhealthy node
+                  and delete them. The latter will add the out-of-service taint which
+                  is a new well-known taint "node.kubernetes.io/out-of-service" that
+                  enables automatic deletion of pv-attached pods on failed nodes.
                 enum:
                 - ResourceDeletion
+                - OutOfServiceTaint
                 type: string
             type: object
           status:

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -52,13 +52,16 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes currently "NodeDeletion" is deprecated
-                          and "ResourceDeletion" will always happen, regardless of
-                          which strategy is selected it will iterate over all pods
-                          and volume attachments related to the unhealthy node and
-                          delete them
+                          for unhealthy nodes. Currently "NodeDeletion" is deprecated
+                          and it could be either "ResourceDeletion" or "OutOfServiceTaint".
+                          The first will iterate over all pods and VolumeAttachment
+                          related to the unhealthy node and delete them. The latter
+                          will add the out-of-service taint which is a new well-known
+                          taint "node.kubernetes.io/out-of-service" that enables automatic
+                          deletion of pv-attached pods on failed nodes.
                         enum:
                         - ResourceDeletion
+                        - OutOfServiceTaint
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -42,12 +42,15 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes currently "NodeDeletion" is deprecated and "ResourceDeletion"
-                  will always happen, regardless of which strategy is selected it
-                  will iterate over all pods and volume attachments related to the
-                  unhealthy node and delete them
+                  nodes. Currently "NodeDeletion" is deprecated and it could be either
+                  "ResourceDeletion" or "OutOfServiceTaint". The first will iterate
+                  over all pods and VolumeAttachment related to the unhealthy node
+                  and delete them. The latter will add the out-of-service taint which
+                  is a new well-known taint "node.kubernetes.io/out-of-service" that
+                  enables automatic deletion of pv-attached pods on failed nodes.
                 enum:
                 - ResourceDeletion
+                - OutOfServiceTaint
                 type: string
             type: object
           status:

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -51,13 +51,16 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes currently "NodeDeletion" is deprecated
-                          and "ResourceDeletion" will always happen, regardless of
-                          which strategy is selected it will iterate over all pods
-                          and volume attachments related to the unhealthy node and
-                          delete them
+                          for unhealthy nodes. Currently "NodeDeletion" is deprecated
+                          and it could be either "ResourceDeletion" or "OutOfServiceTaint".
+                          The first will iterate over all pods and VolumeAttachment
+                          related to the unhealthy node and delete them. The latter
+                          will add the out-of-service taint which is a new well-known
+                          taint "node.kubernetes.io/out-of-service" that enables automatic
+                          deletion of pv-attached pods on failed nodes.
                         enum:
                         - ResourceDeletion
+                        - OutOfServiceTaint
                         type: string
                     type: object
                 required:

--- a/controllers/selfnoderemediation_controller_test.go
+++ b/controllers/selfnoderemediation_controller_test.go
@@ -83,6 +83,15 @@ var _ = Describe("snr Controller", func() {
 			})
 		})
 
+		Context("OutOfServiceTaint strategy", func() {
+			BeforeEach(func() {
+				remediationStrategy = v1alpha1.OutOfServiceTaintRemediationStrategy
+			})
+
+			It("snr should not have finalizers", func() {
+				testNoFinalizer()
+			})
+		})
 	})
 
 	Context("Unhealthy node with self-node-remediation pod but unable to reboot", func() {
@@ -192,6 +201,59 @@ var _ = Describe("snr Controller", func() {
 
 			})
 		})
+
+		Context("OutOfServiceTaint strategy", func() {
+			var vaName = "some-va"
+
+			BeforeEach(func() {
+				remediationStrategy = v1alpha1.OutOfServiceTaintRemediationStrategy
+
+				createVolumeAttachment(vaName)
+			})
+
+			AfterEach(func() {
+				//no need to delete pp pod or va as it was already deleted by the controller
+			})
+
+			It("Remediation flow", func() {
+				node := verifyNodeIsUnschedulable()
+
+				addUnschedulableTaint(node)
+
+				// The normal NoExecute taint tries to delete pods, however it can't delete pods
+				// with stateful workloads like volumes and they are stuck in terminating status.
+				createTerminatingPod()
+
+				verifyTimeHasBeenRebootedExists()
+
+				verifyNoWatchdogFood()
+
+				verifyFinalizerExists()
+
+				verifyNoExecuteTaintExist()
+
+				verifyOutOfServiceTaintExist()
+
+				// simulate the out-of-service taint by Pod GC Controller
+				deleteTerminatingPod()
+				deleteVolumeAttachment(vaName)
+
+				verifyOutOfServiceTaintRemoved()
+
+				deleteSNR(snr)
+				isSNRNeedsDeletion = false
+
+				verifyNodeIsSchedulable()
+
+				removeUnschedulableTaint()
+
+				verifyNoExecuteTaintRemoved()
+
+				verifySNRDoesNotExists()
+
+			})
+		})
+
 	})
 
 	Context("Unhealthy node without api-server access", func() {
@@ -258,6 +320,16 @@ func verifyProcessingCondition(conditionStatus metav1.ConditionStatus) {
 	}, 5*time.Second, 250*time.Millisecond).Should(BeTrue())
 }
 
+func deleteVolumeAttachment(vaName string) {
+	va := &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vaName,
+			Namespace: namespace,
+		},
+	}
+	ExpectWithOffset(1, k8sClient.Delete(context.Background(), va)).To(Succeed())
+}
+
 func verifyVaDeleted(vaName string) {
 	vaKey := client.ObjectKey{
 		Namespace: namespace,
@@ -314,22 +386,40 @@ func verifyFinalizerExists() {
 
 func verifyNoExecuteTaintRemoved() {
 	By("Verify that node does not have NoExecute taint")
-	Eventually(isNoExecuteTaintExist, 10*time.Second, 200*time.Millisecond).Should(BeFalse())
+	Eventually(func() (bool, error) {
+		return isTaintExist(controllers.NodeNoExecuteTaint)
+	}, 10*time.Second, 200*time.Millisecond).Should(BeFalse())
 }
 
 func verifyNoExecuteTaintExist() {
 	By("Verify that node has NoExecute taint")
-	Eventually(isNoExecuteTaintExist, 10*time.Second, 200*time.Millisecond).Should(BeTrue())
+	Eventually(func() (bool, error) {
+		return isTaintExist(controllers.NodeNoExecuteTaint)
+	}, 10*time.Second, 200*time.Millisecond).Should(BeTrue())
 }
 
-func isNoExecuteTaintExist() (bool, error) {
+func verifyOutOfServiceTaintRemoved() {
+	By("Verify that node does not have out-of-service taint")
+	Eventually(func() (bool, error) {
+		return isTaintExist(controllers.OutOfServiceTaint)
+	}, 10*time.Second, 200*time.Millisecond).Should(BeFalse())
+}
+
+func verifyOutOfServiceTaintExist() {
+	By("Verify that node has out-of-service taint")
+	Eventually(func() (bool, error) {
+		return isTaintExist(controllers.OutOfServiceTaint)
+	}, 10*time.Second, 200*time.Millisecond).Should(BeTrue())
+}
+
+func isTaintExist(taintToMatch *v1.Taint) (bool, error) {
 	node := &v1.Node{}
 	err := k8sClient.Reader.Get(context.TODO(), unhealthyNodeNamespacedName, node)
 	if err != nil {
 		return false, err
 	}
 	for _, taint := range node.Spec.Taints {
-		if controllers.NodeNoExecuteTaint.MatchTaint(&taint) {
+		if taintToMatch.MatchTaint(&taint) {
 			return true, nil
 		}
 	}
@@ -424,6 +514,39 @@ func deleteSelfNodeRemediationPod() {
 	pod := &v1.Pod{}
 	pod.Name = "self-node-remediation"
 	pod.Namespace = namespace
+	podKey := client.ObjectKey{
+		Namespace: namespace,
+		Name:      pod.Name,
+	}
+
+	var grace client.GracePeriodSeconds = 0
+	ExpectWithOffset(1, k8sClient.Client.Delete(context.Background(), pod, grace)).To(Succeed())
+
+	EventuallyWithOffset(1, func() bool {
+		err := k8sClient.Client.Get(context.Background(), podKey, pod)
+		return apierrors.IsNotFound(err)
+	}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+}
+
+func createTerminatingPod() {
+	pod := &v1.Pod{}
+	pod.Spec.NodeName = unhealthyNodeName
+	pod.Name = "terminatingpod"
+	pod.Namespace = "default"
+	container := v1.Container{
+		Name:  "bar",
+		Image: "bar",
+	}
+	pod.Spec.Containers = []v1.Container{container}
+	now := metav1.Now()
+	pod.ObjectMeta = metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace, DeletionTimestamp: &now}
+	ExpectWithOffset(1, k8sClient.Client.Create(context.Background(), pod)).To(Succeed())
+}
+
+func deleteTerminatingPod() {
+	pod := &v1.Pod{}
+	pod.Name = "terminatingpod"
+	pod.Namespace = "default"
 	podKey := client.ObjectKey{
 		Namespace: namespace,
 		Name:      pod.Name,


### PR DESCRIPTION
This PR is adding a new remediation strategy based on https://github.com/kubernetes/enhancements/pull/1116
In k8s 1.26, https://github.com/kubernetes/enhancements/pull/1116 is a Beta feature. This feature will be graduated to GA in k8s 1.27.

This PR is implemented based on the discussion in https://github.com/medik8s/self-node-remediation/issues/17.
The following is the new remediation strategy for the out-of-service taint:

1. When detecting node failure by NHC, SNR sets NoExecute taint on the failed Node
2. The failed node is rebooted by watchdog
3. SNR waits for a fixed time to complete rebooting the failed node
4. SNR sets the out-of-service taint
=> This taint expects that the node is in shutdown or power off state (not in the middle of restarting) according to [the enhancement](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2268-non-graceful-shutdown#proposal.)
      However, SNR works well with this taint as we discussed in https://github.com/medik8s/self-node-remediation/issues/17#issuecomment-1155947689.
5. If the failed node is rebooted and there is no terminating pods and volumeattachements, SNR deletes the out-of-service taint.
=> SNR waits for deleting workloads on the failed node with a timer. If the timer is expired, the reconcile method is triggered. 
6. The fencing complete is set
7. After setting the fencing complete, it starts cleaning up and then the NoExecute taint is deleted and the failed node becomes schedulable again
8. The remediation is completed.
