### PR TITLE
Reduce timeout for compact (or otherwise small) clusters

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -93,15 +93,12 @@ type SelfNodeRemediationReconciler struct {
 	client.Client
 	Log logr.Logger
 	//logger is a logger that holds the CR name being reconciled
-	logger   logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Rebooter reboot.Rebooter
-	// note that this time must include the time for a unhealthy node without api-server access to reach the conclusion that it's unhealthy
-	// this should be at least worst-case time to reach a conclusion from the other peers * request context timeout + watchdog interval + maxFailuresThreshold * reconcileInterval + padding
-	SafeTimeToAssumeNodeRebooted time.Duration
-	MyNodeName                   string
-	mutex                        sync.Mutex
+	logger     logr.Logger
+	Scheme     *runtime.Scheme
+	Recorder   record.EventRecorder
+	Rebooter   reboot.Rebooter
+	MyNodeName string
+	mutex      sync.Mutex
 	//we need to restore the node only after the cluster realized it can reschecudle the affected workloads
 	//as of writing this lines, kubernetes will check for pods with non-existent node once in 20s, and allows
 	//40s of grace period for the node to reappear before it deletes the pods.
@@ -431,7 +428,7 @@ func (r *SelfNodeRemediationReconciler) getReadyCond(node *v1.Node) *v1.NodeCond
 func (r *SelfNodeRemediationReconciler) updateSnrStatus(node *v1.Node, snr *v1alpha1.SelfNodeRemediation) (ctrl.Result, error) {
 	r.logger.Info("updating snr with node backup and updating time to assume node has been rebooted", "node name", node.Name)
 	//we assume the unhealthy node will be rebooted by maxTimeNodeHasRebooted
-	maxTimeNodeHasRebooted := metav1.NewTime(metav1.Now().Add(r.SafeTimeToAssumeNodeRebooted))
+	maxTimeNodeHasRebooted := metav1.NewTime(metav1.Now().Add(r.Rebooter.GetTimeToAssumeNodeRebooted()))
 	snr.Status.TimeAssumedRebooted = &maxTimeNodeHasRebooted
 
 	err := r.Client.Status().Update(context.Background(), snr)

--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	peerRequestTimeout := getDurEnvVarOrDie("PEER_REQUEST_TIMEOUT")   //timeout for each peer request
 	timeToAssumeNodeRebooted := getDurEnvVarOrDie("TIME_TO_ASSUME_NODE_REBOOTED")
 
-	safeRebootCalc := reboot.New(mgr.GetClient(), wd, maxErrorThreshold, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, timeToAssumeNodeRebooted)
+	safeRebootCalc := reboot.NewSafeTimeCalculator(mgr.GetClient(), wd, maxErrorThreshold, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, timeToAssumeNodeRebooted)
 	if err = mgr.Add(safeRebootCalc); err != nil {
 		setupLog.Error(err, "failed to add safe reboot time calculator to the manager")
 		os.Exit(1)

--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -142,10 +142,10 @@ func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {
 	for i := 0; len(nodesToAsk) > 0; i++ {
 
 		// start asking a few nodes only in first iteration to cover the case we get a healthy / unhealthy result
-		nodesBatchCount := 3
+		nodesBatchCount := reboot.NodesNumberInFirstBatch
 		if i > 0 {
 			// after that ask 10% of the cluster each time to check the api problem case
-			nodesBatchCount = len(nodesToAsk) / 10
+			nodesBatchCount = len(nodesToAsk) / reboot.MaxBatchesAfterFirst
 			if nodesBatchCount == 0 {
 				nodesBatchCount = 1
 			}

--- a/pkg/reboot/calculator.go
+++ b/pkg/reboot/calculator.go
@@ -1,0 +1,101 @@
+package reboot
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+
+	"github.com/medik8s/self-node-remediation/pkg/utils"
+	"github.com/medik8s/self-node-remediation/pkg/watchdog"
+)
+
+const (
+	MaxTimeForNoPeersResponse = 30 * time.Second
+)
+
+type SafeTimeCalculator interface {
+	GetTimeToAssumeNodeRebooted() time.Duration
+	Start(ctx context.Context) error
+}
+
+type safeTimeCalculator struct {
+	timeToAssumeNodeRebooted                                                time.Duration
+	wd                                                                      watchdog.Watchdog
+	maxErrorThreshold                                                       int
+	apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout time.Duration
+	log                                                                     logr.Logger
+	k8sClient                                                               client.Client
+}
+
+func New(k8sClient client.Client, wd watchdog.Watchdog, maxErrorThreshold int, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, timeToAssumeNodeRebooted time.Duration) SafeTimeCalculator {
+	return &safeTimeCalculator{
+		wd:                       wd,
+		maxErrorThreshold:        maxErrorThreshold,
+		apiCheckInterval:         apiCheckInterval,
+		apiServerTimeout:         apiServerTimeout,
+		peerDialTimeout:          peerDialTimeout,
+		peerRequestTimeout:       peerRequestTimeout,
+		timeToAssumeNodeRebooted: timeToAssumeNodeRebooted,
+		k8sClient:                k8sClient,
+		log:                      ctrl.Log.WithName("safe-time-calculator"),
+	}
+}
+
+func (s *safeTimeCalculator) GetTimeToAssumeNodeRebooted() time.Duration {
+	return s.timeToAssumeNodeRebooted
+}
+
+//goland:noinspection GoUnusedParameter
+func (s *safeTimeCalculator) Start(ctx context.Context) error {
+	s.calcTimeAssumeRebooted()
+	return nil
+}
+
+func (s *safeTimeCalculator) calcTimeAssumeRebooted() {
+	// but the reboot time needs be at least the time we know we need for determining a node issue and trigger the reboot!
+	// 1. time for determine node issue
+	minTimeToAssumeNodeRebooted := (s.apiCheckInterval+s.apiServerTimeout)*time.Duration(s.maxErrorThreshold) + MaxTimeForNoPeersResponse
+	// 2. time for asking peers (10% batches + 1st smaller batch)
+	minTimeToAssumeNodeRebooted += s.calcNumOfBatches() * (s.peerDialTimeout + s.peerRequestTimeout)
+	// 3. watchdog timeout
+	if s.wd != nil {
+		minTimeToAssumeNodeRebooted += s.wd.GetTimeout()
+	}
+	// 4. some buffer
+	minTimeToAssumeNodeRebooted += 15 * time.Second
+	s.log.Info("calculated minTimeToAssumeNodeRebooted is:", "minTimeToAssumeNodeRebooted", minTimeToAssumeNodeRebooted)
+	if s.timeToAssumeNodeRebooted < minTimeToAssumeNodeRebooted {
+		s.timeToAssumeNodeRebooted = minTimeToAssumeNodeRebooted
+	}
+}
+
+func (s *safeTimeCalculator) calcNumOfBatches() time.Duration {
+
+	reqPeers, _ := labels.NewRequirement(utils.WorkerLabelName, selection.Exists, []string{})
+	selector := labels.NewSelector()
+	selector = selector.Add(*reqPeers)
+
+	nodes := &v1.NodeList{}
+	// time for asking peers (10% batches + 1st smaller batch)
+	numberOfBatches := 10
+	if err := s.k8sClient.List(context.Background(), nodes, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		s.log.Error(err, "couldn't fetch worker nodes")
+		return time.Duration(numberOfBatches)
+	}
+
+	//in case there are less than 10 worker peers we can cover all of them with less than batches
+	if workerNodesCount := len(nodes.Items); workerNodesCount > 0 && workerNodesCount < numberOfBatches {
+		numberOfBatches = workerNodesCount
+	}
+
+	numberOfBatches = numberOfBatches + 1
+	return time.Duration(numberOfBatches)
+}

--- a/pkg/reboot/rebooter.go
+++ b/pkg/reboot/rebooter.go
@@ -14,6 +14,10 @@ const TimeToAssumeRebootHasStarted = time.Second * 30
 type Rebooter interface {
 	// Reboot triggers a node reboot
 	Reboot() error
+	// GetTimeToAssumeNodeRebooted returns the safe time to assume node was already rebooted
+	// note that this time must include the time for a unhealthy node without api-server access to reach the conclusion that it's unhealthy
+	// this should be at least worst-case time to reach a conclusion from the other peers * request context timeout + watchdog interval + maxFailuresThreshold * reconcileInterval + padding
+	GetTimeToAssumeNodeRebooted() time.Duration
 }
 
 var _ Rebooter = &watchdogRebooter{}
@@ -23,15 +27,21 @@ type watchdogRebooter struct {
 	wd                 watchdog.Watchdog
 	log                logr.Logger
 	softwareRebootHook func() error
+	safeTimeCalc       SafeTimeCalculator
 }
 
-func NewWatchdogRebooter(wd watchdog.Watchdog, log logr.Logger) Rebooter {
+func NewWatchdogRebooter(wd watchdog.Watchdog, log logr.Logger, safeTimeCalc SafeTimeCalculator) Rebooter {
 	wdRebooter := &watchdogRebooter{
-		wd:  wd,
-		log: log,
+		wd:           wd,
+		log:          log,
+		safeTimeCalc: safeTimeCalc,
 	}
 	wdRebooter.softwareRebootHook = wdRebooter.softwareReboot
 	return wdRebooter
+}
+
+func (r *watchdogRebooter) GetTimeToAssumeNodeRebooted() time.Duration {
+	return r.safeTimeCalc.GetTimeToAssumeNodeRebooted()
 }
 
 func (r *watchdogRebooter) Reboot() error {

--- a/pkg/reboot/rebooter_test.go
+++ b/pkg/reboot/rebooter_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Rebooter tests", func() {
 	Describe("Crash on start", func() {
 		BeforeEach(func() {
 			wd, _ := watchdog.NewFake(false)
-			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot}
+			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot, nil}
 
 		})
 


### PR DESCRIPTION
[ECOPROJECT-1197](https://issues.redhat.com//browse/ECOPROJECT-1197)
ATM when we calculate SNR timeout we are sampling all the worker nodes in batches of 10% of the nodes in each batch.
Therefore we calculate the timeout assuming 10 batches.
In case a cluster has fewer than 10 worker nodes this calculation can be optimized.