### PR TITLE
Avoid SelfNodeRemediation object being deleted before remediation is complete.

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -213,15 +213,15 @@ func (r *SelfNodeRemediationReconciler) remediateWithResourceDeletion(snr *v1alp
 		return ctrl.Result{}, nil
 	}
 
+	if !controllerutil.ContainsFinalizer(snr, SNRFinalizer) {
+		return r.addFinalizer(snr)
+	}
+
 	r.logger.Info("fencing not completed yet, continuing remediation")
 
 	if !r.isNodeRebootCapable(node) {
 		//use err to trigger exponential backoff
 		return ctrl.Result{}, errors.New("Node is not capable to reboot itself")
-	}
-
-	if !controllerutil.ContainsFinalizer(snr, SNRFinalizer) {
-		return r.addFinalizer(snr)
 	}
 
 	if err = r.addNoExecuteTaint(node); err != nil {


### PR DESCRIPTION
This tries to fix an existing race condition when a SelfNodeRemediation object is created and immediately scheduled for 'Foreground' deletion from K8s.

When a SelfNodeRemediation object is created the object has the 'ownerReferences' field set, and this immediately schedules it for deletion.
If a 'finalizer' is not set immediately the object gets deleted and no remediation is triggered for the Node.
The idea for the fix is the object to have a 'finalizer' set right after a reconcile request is triggered.
Although this might not be the best solution for the problem!

This happens only once when the cluster is initially started.
Every subsequent attempt for 'remediation' is successful afterwards.
After a reconcile request is received `isNodeRebootCapable()` is checked, which itself lists all the Pods from the DS and at only first run controller-runtime library cache is still empty.
During the time that Pod information is fetched from the K8s API server and not from the client's cache, the 'SelfNodeRemediation' object is already deleted without the protection of the 'finalizer' set right afterwards.

Typical logs with timestamps when the issue is hit.
```
2023-02-17T09:34:16.515Z INFO controller-runtime.metrics metrics server is starting to listen {"addr": ":8080"}
2023-02-17T09:34:16.517Z INFO setup Starting as a self node remediation agent that should run as part of the daemonset
2023-02-17T09:34:16.543Z INFO setup Time to assume that unhealthy node has been rebooted {"time": "3m5s"}
2023-02-17T09:34:16.544Z INFO setup init grpc server
2023-02-17T09:34:16.544Z INFO setup starting manager
2023-02-17T09:34:16.544Z INFO controller-runtime.manager.controller.selfnoderemediation Starting EventSource {"reconciler group": "self-node-remediation.medik8s.io", "reconciler kind": "SelfNodeRemediation", "source": "kind source: /, Kind="}
2023-02-17T09:34:16.544Z INFO controller-runtime.manager.controller.selfnoderemediation Starting Controller {"reconciler group": "self-node-remediation.medik8s.io", "reconciler kind": "SelfNodeRemediation"}
2023-02-17T09:34:16.544Z INFO watchdog watchdog started
2023-02-17T09:34:16.545Z INFO api-check api connectivity check started
2023-02-17T09:34:16.544Z INFO controller-runtime.manager starting metrics server {"path": "/metrics"}
2023-02-17T09:34:16.645Z INFO controller-runtime.manager.controller.selfnoderemediation Starting workers {"reconciler group": "self-node-remediation.medik8s.io", "reconciler kind": "SelfNodeRemediation", "worker count": 1}
2023-02-17T09:34:16.645Z INFO peers peers started
2023-02-17T09:34:16.645Z INFO peerhealth.server peer health server started
2023-02-17T09:36:36.649Z INFO controllers.SelfNodeRemediation fencing not completed yet, continuing remediation {"selfnoderemediation": "self-node-remediation/k8s-node6"}
2023-02-17T09:36:36.756Z INFO controllers.SelfNodeRemediation SNR already deleted {"selfnoderemediation": "self-node-remediation/k8s-node6"}
2023-02-17T09:36:37.759Z INFO controllers.SelfNodeRemediation SNR already deleted {"selfnoderemediation": "self-node-remediation/k8s-node6"} 
```
And of course, no remediation hasn't been triggered at all.

A way to reproduce it.
- Reload all the self-node-remediation operator DS Pods so the cache is lost.
- Execute 
```
cat <<EOF | kubectl apply -f -
apiVersion: self-node-remediation.medik8s.io/v1alpha1
kind: SelfNodeRemediation
metadata:
  name: k8s-node6
  namespace: self-node-remediation
  ownerReferences:
  - apiVersion: remediation.medik8s.io/v1alpha1
    controller: false
    kind: NodeHealthCheck
    name: nodehealthcheck-sample
    uid: fe293bb4-ce1e-4b01-b6f4-7f6f08ec6958
spec:
  remediationStrategy: ResourceDeletion
EOF
```