### PR TITLE
Add RBAC permissions for namespaces.

### DIFF
--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -121,6 +121,14 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apps
           resources:
           - daemonsets

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -127,6 +127,7 @@ func (r *SelfNodeRemediationReconciler) SetupWithManager(mgr ctrl.Manager) error
 //+kubebuilder:rbac:groups=self-node-remediation.medik8s.io,resources=selfnoderemediations/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=list;get;watch
 
 func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.logger = r.Log.WithValues("selfnoderemediation", req.NamespacedName)


### PR DESCRIPTION
This fixes errors like the one reported in the logs.

```
E0203 12:05:27.009380 2699 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.3/tools/cache/reflector.go:167: Failed to watch *v1.Namespace: failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:self-node-remediation:self-node-remediation-controller-manager" cannot list resource "namespaces" in API group "" at the cluster scope 
E0203 13:00:27.442104 2699 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.3/tools/cache/reflector.go:167: Failed to watch *v1.Namespace: unknown (get namespaces) 
```

Relevant Jira ticket - [ECOPROJECT-1183](https://issues.redhat.com//browse/ECOPROJECT-1183)