### PR TITLE
increase the minimum batch size

### DIFF
--- a/pkg/apicheck/check.go
+++ b/pkg/apicheck/check.go
@@ -142,16 +142,16 @@ func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {
 	for i := 0; len(nodesToAsk) > 0; i++ {
 
 		// start asking a few nodes only in first iteration to cover the case we get a healthy / unhealthy result
-		nodesBatchCount := reboot.NodesNumberInFirstBatch
+		nodesBatchCount := reboot.MinNodesNumberInBatch
 		if i > 0 {
 			// after that ask 10% of the cluster each time to check the api problem case
 			nodesBatchCount = len(nodesToAsk) / reboot.MaxBatchesAfterFirst
-			if nodesBatchCount == 0 {
-				nodesBatchCount = 1
+			if nodesBatchCount < reboot.MinNodesNumberInBatch {
+				nodesBatchCount = reboot.MinNodesNumberInBatch
 			}
 		}
 
-		// but do not ask more then we have
+		// but do not ask more than we have
 		if len(nodesToAsk) < nodesBatchCount {
 			nodesBatchCount = len(nodesToAsk)
 		}

--- a/pkg/reboot/calculator.go
+++ b/pkg/reboot/calculator.go
@@ -98,7 +98,7 @@ func (s *safeTimeCalculator) calcNumOfBatches() int {
 
 	var numberOfBatches int
 	switch {
-	//high number of workers we need max batches (for example 53 nodes will be done in 11 batches -> 1 * 3 + 10 * 5 )
+	//high number of workers: we need max batches (for example 53 nodes will be done in 11 batches -> 1 * 3 + 10 * 5 )
 	case workerNodesCount > maxNumberOfBatches*MinNodesNumberInBatch:
 		numberOfBatches = maxNumberOfBatches
 	//there are few enough nodes to use the min batch (for example 20 nodes will be done in 7 batches -> 1 * 3 +  6 * 3 )


### PR DESCRIPTION
Followup PR for [this](https://github.com/medik8s/self-node-remediation/pull/91#pullrequestreview-1317265132) comment.
increase the minimum number of worker nodes in each batch from 1 to 3 in order to reduce timeout in clusters with low number of worker nodes.