### PR TITLE
Extend Bundle Validation with bundle-validate Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,13 +240,12 @@ bundle: manifests operator-sdk kustomize ## Generate bundle manifests and metada
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | envsubst | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	$(OPERATOR_SDK) bundle validate ./bundle
+	$(MAKE) bundle-validate
 
 .PHONY: bundle-k8s
 bundle-k8s: bundle ## Generate bundle manifests and metadata customized to k8s community release, then validate generated files.
 	# Note that k8s 1.25+ needs PSA label
 	sed -r -i "s|by default\.|by default.\n    Note that prior to installing SNR on a Kubernetes 1.25+ cluster, a user must manually set a [privileged PSA label](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/) on SNR's namespace. It gives SNR's agents permissions to reboot the node (in case it needs to be remediated).|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
-
 
 .PHONY: bundle-update
 bundle-update:
@@ -258,9 +257,12 @@ bundle-update:
 	sed -r -i "s|olm.skipRange: .*|olm.skipRange: '>=0.4.0 <${VERSION}'|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
 	# set icon (not version or build date related, but just to not having this huge data permanently in the CSV)
 	sed -r -i "s|base64data:.*|base64data: ${ICON_BASE64}|;" ./bundle/manifests/$(OPERATOR_NAME).clusterserviceversion.yaml
-	$(OPERATOR_SDK) bundle validate ./bundle
+	$(MAKE) bundle-validate
 
-
+.PHONY: bundle-validate
+bundle-validate: operator-sdk ## Validate the bundle directory with additional validators (suite=operatorframework), such as Kubernetes deprecated APIs (https://kubernetes.io/docs/reference/using-api/deprecation-guide/) based on bundle.CSV.Spec.MinKubeVersion
+	$(OPERATOR_SDK) bundle validate ./bundle --select-optional suite=operatorframework
+	
 .PHONY: bundle-build
 bundle-build: bundle bundle-update ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .


### PR DESCRIPTION
Running the operator-sdk validation without any flags validates the bundle format and conforms it's contents to what is allowed in a `registry+v1` bundle (see [ValidateBundleFormat and ValidateBundleContent](https://github.com/operator-framework/operator-sdk/blob/a5d933b5e8d729c9c3f9f1790f61053cf37dfafd/internal/cmd/operator-sdk/bundle/validate/validate.go#L163-L170) functions).

This PR (Similar PR to [NMO's PR](https://github.com/medik8s/node-maintenance-operator/pull/64)) extends our [bundle validation](https://sdk.operatorframework.io/docs/cli/operator-sdk_bundle_validate/) to three more [validators](https://github.com/operator-framework/operator-sdk/blob/a5d933b5e8d729c9c3f9f1790f61053cf37dfafd/internal/cmd/operator-sdk/bundle/validate/optional.go#L37-L81) (from `operatorframework` suite):

- **[operatorhub](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/operatorhub.go#L160)** validates the bundle manifests against the required criteria to publish
// the projects on OperatorHub.io.
- **[alpha-deprecated-apis](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/removed_apis.go#L55)** validates the bundle for [Kubernetes deprecated APIs](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) versions based on the [_bundle.CSV.Spec.MinKubeVersion_](https://github.com/medik8s/node-maintenance-operator/blob/main/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml#L345) value (and `--optional-values=k8s-version=K8S_VERSION` if provided) . 
The validation will error if it knows you are using a deprecated API and warn if it thinks there could be a deprecated API being used. Currently, _operator-sdk v1.26.0_, it supports only three [deprecated Kubernetes API versions](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/removed_apis.go#L30).
- **[good-practices](https://github.com/operator-framework/api/blob/master/pkg/validation/internal/good_practices.go#L41)** validates the bundle against criteria and suggestions defined as good practices for bundles under the [operator-framework solutions](https://sdk.operatorframework.io/docs/best-practices/).

To see more options for using the bundle validation - Please run `operator-sdk bundle validate --list-optional`