### PR TITLE
Validate k8s version for out-of-service-taint remediation strategy

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -24,6 +24,9 @@ resources:
   kind: SelfNodeRemediationTemplate
   path: github.com/medik8s/self-node-remediation/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var (
+	log = logf.Log.WithName("selfnoderemediationtemplate-resource")
+
+	//out of service taint strategy params
+	isOutOfServiceTaintSupported             bool
+	minK8sVersionSupportingOutOfServiceTaint = 1.26
+)
+
+func (r *SelfNodeRemediationTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+
+	if err := initOutOfServiceTaintSupportedFlag(mgr.GetConfig()); err != nil {
+		return err
+	}
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=self-node-remediation.medik8s.io,resources=selfnoderemediationtemplates,verbs=create;update,versions=v1alpha1,name=vselfnoderemediationtemplate.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &SelfNodeRemediationTemplate{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *SelfNodeRemediationTemplate) ValidateCreate() error {
+	log.Info("validate create", "name", r.Name)
+	return validateStrategy(r.Spec.Template.Spec)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *SelfNodeRemediationTemplate) ValidateUpdate(_ runtime.Object) error {
+	log.Info("validate update", "name", r.Name)
+	return validateStrategy(r.Spec.Template.Spec)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *SelfNodeRemediationTemplate) ValidateDelete() error {
+	// unused for now, add "delete" when needed to verbs in the kubebuilder annotation above
+	log.Info("validate delete", "name", r.Name)
+	return nil
+}
+
+func validateStrategy(snrSpec SelfNodeRemediationSpec) error {
+	if snrSpec.RemediationStrategy == OutOfServiceTaintRemediationStrategy && !isOutOfServiceTaintSupported {
+		return fmt.Errorf("%s remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy", OutOfServiceTaintRemediationStrategy)
+	}
+	return nil
+}
+
+func initOutOfServiceTaintSupportedFlag(config *rest.Config) error {
+	if cs, err := kubernetes.NewForConfig(config); err != nil || cs == nil {
+		if cs == nil {
+			err = fmt.Errorf("k8s client set is nil")
+		}
+		log.Error(err, "couldn't get retrieve k8s client")
+		return err
+	} else if version, err := cs.Discovery().ServerVersion(); err != nil || version == nil {
+		if version == nil {
+			err = fmt.Errorf("k8s server version is nil")
+		}
+		log.Error(err, "couldn't get retrieve k8s server version")
+		return err
+	} else {
+		k8sVersion, err := strconv.ParseFloat(fmt.Sprintf("%s.%s", version.Major, version.Minor), 8)
+		if err != nil {
+			log.Error(err, "couldn't get parse k8s server version", "Major", version.Major, "Minor", version.Minor)
+			return err
+		}
+
+		isOutOfServiceTaintSupported = k8sVersion >= minK8sVersionSupportingOutOfServiceTaint
+		log.Info("out of service taint strategy", "isSupported", isOutOfServiceTaintSupported, "k8sVersion", k8sVersion)
+		return nil
+	}
+}

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook.go
@@ -29,13 +29,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-// log is for logging in this package.
-var (
-	log = logf.Log.WithName("selfnoderemediationtemplate-resource")
-
-	//out of service taint strategy params
-	isOutOfServiceTaintSupported             bool
+const (
+	//out of service taint strategy const
 	minK8sVersionSupportingOutOfServiceTaint = 1.26
+)
+
+var (
+	// snrtWebookLog is for logging in this package.
+	snrtWebookLog = logf.Log.WithName("selfnoderemediationtemplate-resource")
+	//out of service taint strategy params
+	isOutOfServiceTaintSupported bool
 )
 
 func (r *SelfNodeRemediationTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -55,20 +58,20 @@ var _ webhook.Validator = &SelfNodeRemediationTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *SelfNodeRemediationTemplate) ValidateCreate() error {
-	log.Info("validate create", "name", r.Name)
+	snrtWebookLog.Info("validate create", "name", r.Name)
 	return validateStrategy(r.Spec.Template.Spec)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *SelfNodeRemediationTemplate) ValidateUpdate(_ runtime.Object) error {
-	log.Info("validate update", "name", r.Name)
+	snrtWebookLog.Info("validate update", "name", r.Name)
 	return validateStrategy(r.Spec.Template.Spec)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *SelfNodeRemediationTemplate) ValidateDelete() error {
 	// unused for now, add "delete" when needed to verbs in the kubebuilder annotation above
-	log.Info("validate delete", "name", r.Name)
+	snrtWebookLog.Info("validate delete", "name", r.Name)
 	return nil
 }
 
@@ -84,23 +87,23 @@ func initOutOfServiceTaintSupportedFlag(config *rest.Config) error {
 		if cs == nil {
 			err = fmt.Errorf("k8s client set is nil")
 		}
-		log.Error(err, "couldn't get retrieve k8s client")
+		snrtWebookLog.Error(err, "couldn't get retrieve k8s client")
 		return err
 	} else if version, err := cs.Discovery().ServerVersion(); err != nil || version == nil {
 		if version == nil {
 			err = fmt.Errorf("k8s server version is nil")
 		}
-		log.Error(err, "couldn't get retrieve k8s server version")
+		snrtWebookLog.Error(err, "couldn't get retrieve k8s server version")
 		return err
 	} else {
 		k8sVersion, err := strconv.ParseFloat(fmt.Sprintf("%s.%s", version.Major, version.Minor), 8)
 		if err != nil {
-			log.Error(err, "couldn't get parse k8s server version", "Major", version.Major, "Minor", version.Minor)
+			snrtWebookLog.Error(err, "couldn't get parse k8s server version", "Major", version.Major, "Minor", version.Minor)
 			return err
 		}
 
 		isOutOfServiceTaintSupported = k8sVersion >= minK8sVersionSupportingOutOfServiceTaint
-		log.Info("out of service taint strategy", "isSupported", isOutOfServiceTaintSupported, "k8sVersion", k8sVersion)
+		snrtWebookLog.Info("out of service taint strategy", "isSupported", isOutOfServiceTaintSupported, "k8sVersion", k8sVersion)
 		return nil
 	}
 }

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -98,15 +97,12 @@ func initOutOfServiceTaintSupportedFlag(config *rest.Config) error {
 		snrtWebookLog.Error(err, "couldn't get retrieve k8s server version")
 		return err
 	} else {
-		isOutOfServiceTaintSupported = strings.Compare(fmt.Sprintf("%s.%s", version.Major, version.Minor), "1.26") >= 0
-
-		var majorVer, minorVer int64
-		if majorVer, err = strconv.ParseInt(version.Major, 10, 8); err != nil {
+		var majorVer, minorVer int
+		if majorVer, err = strconv.Atoi(version.Major); err != nil {
 			snrtWebookLog.Error(err, "couldn't parse k8s major version", "major version", version.Major)
 			return err
 		}
-
-		if minorVer, err = strconv.ParseInt(version.Major, 10, 8); err != nil {
+		if minorVer, err = strconv.Atoi(version.Major); err != nil {
 			snrtWebookLog.Error(err, "couldn't parse k8s minor version", "minor version", version.Minor)
 			return err
 		}

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook_test.go
@@ -67,13 +67,8 @@ var _ = Describe("SelfNodeRemediationTemplate Validation", func() {
 					isOutOfServiceTaintSupported = false
 				})
 				It("should be denied", func() {
-					err := outOfServiceStrategy.ValidateCreate()
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy"))
-
-					err = outOfServiceStrategy.ValidateUpdate(snrtValid)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy"))
+					Expect(outOfServiceStrategy.ValidateCreate()).To(MatchError(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy")))
+					Expect(outOfServiceStrategy.ValidateUpdate(snrtValid)).To(MatchError(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy")))
 				})
 			})
 

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook_test.go
@@ -1,0 +1,84 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("SelfNodeRemediationTemplate Validation", func() {
+
+	Context("a SNRT", func() {
+
+		var snrtValid *SelfNodeRemediationTemplate
+		var outOfServiceStrategy *SelfNodeRemediationTemplate
+
+		BeforeEach(func() {
+			snrtValid = &SelfNodeRemediationTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: SelfNodeRemediationTemplateSpec{
+					Template: SelfNodeRemediationTemplateResource{
+						Spec: SelfNodeRemediationSpec{
+							RemediationStrategy: ResourceDeletionRemediationStrategy,
+						},
+					},
+				},
+			}
+			outOfServiceStrategy = &SelfNodeRemediationTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: SelfNodeRemediationTemplateSpec{
+					Template: SelfNodeRemediationTemplateResource{
+						Spec: SelfNodeRemediationSpec{
+							RemediationStrategy: OutOfServiceTaintRemediationStrategy,
+						},
+					},
+				},
+			}
+
+		})
+
+		Context("with valid strategy", func() {
+			It("should be allowed", func() {
+				Expect(snrtValid.ValidateCreate()).To(Succeed())
+			})
+		})
+
+		Context("with out Of Service Taint strategy", func() {
+			BeforeEach(func() {
+				orgValue := isOutOfServiceTaintSupported
+				DeferCleanup(func() { isOutOfServiceTaintSupported = orgValue })
+
+			})
+			When("out of service taint is supported", func() {
+				BeforeEach(func() {
+					isOutOfServiceTaintSupported = true
+				})
+				It("should be allowed", func() {
+					Expect(outOfServiceStrategy.ValidateCreate()).To(Succeed())
+					Expect(snrtValid.ValidateUpdate(outOfServiceStrategy)).To(Succeed())
+				})
+			})
+			When("out of service taint is not supported", func() {
+				BeforeEach(func() {
+					isOutOfServiceTaintSupported = false
+				})
+				It("should be denied", func() {
+					err := outOfServiceStrategy.ValidateCreate()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy"))
+
+					err = outOfServiceStrategy.ValidateUpdate(snrtValid)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different remediation strategy"))
+				})
+			})
+
+		})
+
+	})
+
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -98,6 +98,9 @@ var _ = BeforeSuite(func() {
 	err = (&SelfNodeRemediationConfig{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&SelfNodeRemediationTemplate{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	var ctx context.Context

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -460,3 +460,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationconfig
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: self-node-remediation-controller-manager
+    failurePolicy: Fail
+    generateName: vselfnoderemediationtemplate.kb.io
+    rules:
+    - apiGroups:
+      - self-node-remediation.medik8s.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - selfnoderemediationtemplates
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -25,3 +25,23 @@ webhooks:
     resources:
     - selfnoderemediationconfigs
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate
+  failurePolicy: Fail
+  name: vselfnoderemediationtemplate.kb.io
+  rules:
+  - apiGroups:
+    - self-node-remediation.medik8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - selfnoderemediationtemplates
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -137,6 +137,11 @@ func initSelfNodeRemediationManager(mgr manager.Manager) {
 		os.Exit(1)
 	}
 
+	if err := (&selfnoderemediationv1alpha1.SelfNodeRemediationTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "SelfNodeRemediationTemplate")
+		os.Exit(1)
+	}
+
 	ns, err := utils.GetDeploymentNamespace()
 	if err != nil {
 		setupLog.Error(err, "failed to get deployed namespace from env var")


### PR DESCRIPTION
Verifying out of service taint is supported before allowing the user to set it.
