### PR TITLE
Fix validation of k8s version for out-of-service-taint remediation

### DIFF
--- a/api/v1alpha1/selfnoderemediationtemplate_webhook.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook.go
@@ -102,7 +102,7 @@ func initOutOfServiceTaintSupportedFlag(config *rest.Config) error {
 			snrtWebookLog.Error(err, "couldn't parse k8s major version", "major version", version.Major)
 			return err
 		}
-		if minorVer, err = strconv.Atoi(version.Major); err != nil {
+		if minorVer, err = strconv.Atoi(version.Minor); err != nil {
 			snrtWebookLog.Error(err, "couldn't parse k8s minor version", "minor version", version.Minor)
 			return err
 		}


### PR DESCRIPTION
I got the following error when tried to use the OutOfServiceTaint remediation on OCP4.13 rc0:
```
OutOfServiceTaint remediation strategy is not supported at kubernetes version lower than 1.26, please use a different 
remediation strategy
```
This PR changes initOutOfServiceTaintSupportedFlag to parse k8s minor version, not the major version for minorVer.
