### PR TITLE
setting minimum requeue time in case update failed

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -157,8 +157,12 @@ func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.
 	defer func() {
 		if updateErr := r.updateSnrStatus(ctx, snr); updateErr != nil {
 			if apiErrors.IsConflict(updateErr) {
-				if returnErr == nil && !returnResult.Requeue {
-					returnResult = ctrl.Result{RequeueAfter: time.Second}
+				minRequeue := time.Second
+				if returnResult.Requeue && minRequeue > returnResult.RequeueAfter {
+					minRequeue = returnResult.RequeueAfter
+				}
+				if returnErr == nil {
+					returnResult.RequeueAfter = minRequeue
 				}
 			} else {
 				returnErr = utilerrors.NewAggregate([]error{updateErr, returnErr})

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -158,7 +158,8 @@ func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.
 		if updateErr := r.updateSnrStatus(ctx, snr); updateErr != nil {
 			if apiErrors.IsConflict(updateErr) {
 				minRequeue := time.Second
-				if returnResult.Requeue && minRequeue > returnResult.RequeueAfter {
+				//if requeue is already set choose the lowest one
+				if returnResult.RequeueAfter > 0 && minRequeue > returnResult.RequeueAfter {
 					minRequeue = returnResult.RequeueAfter
 				}
 				if returnErr == nil {


### PR DESCRIPTION
As a follow up on [this](https://github.com/medik8s/self-node-remediation/pull/102#discussion_r1156211127) comment, setting minimum requeue time in case update failed instead of keeping the original requeue time.
