### PR TITLE
Allow creating remediation CRs when webhook is down

### DIFF
--- a/api/v1alpha1/selfnoderemediation_webhook.go
+++ b/api/v1alpha1/selfnoderemediation_webhook.go
@@ -33,7 +33,7 @@ func (r *SelfNodeRemediation) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediation,mutating=false,failurePolicy=fail,sideEffects=None,groups=self-node-remediation.medik8s.io,resources=selfnoderemediations,verbs=create;update,versions=v1alpha1,name=vselfnoderemediation.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediation,mutating=false,failurePolicy=ignore,sideEffects=None,groups=self-node-remediation.medik8s.io,resources=selfnoderemediations,verbs=create;update,versions=v1alpha1,name=vselfnoderemediation.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &SelfNodeRemediation{}
 

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -444,7 +444,7 @@ spec:
     - v1
     containerPort: 443
     deploymentName: self-node-remediation-controller-manager
-    failurePolicy: Fail
+    failurePolicy: Ignore
     generateName: vselfnoderemediation.kb.io
     rules:
     - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediation
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vselfnoderemediation.kb.io
   rules:
   - apiGroups:


### PR DESCRIPTION
When the operator is running on the unhealthy node, webhook calls fail, and NHC can't create CRs without this change.
The webhook was introduced for [ECOPROJECT-1232](https://issues.redhat.com//browse/ECOPROJECT-1232) in #108.

`2023-04-05T07:14:23.675898862Z	ERROR	controllers.NodeHealthCheck	failed to start remediation	{"NodeHealthCheck name": "test-nhc", "error": "failed to create remediation CR: Internal error occurred: failed calling webhook \"vselfnoderemediation.kb.io\": failed to call webhook: Post \"[https://self-node-remediation-controller-manager-service.k8s-test.svc:443/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediation?timeout=10s\](https://self-node-remediation-controller-manager-service.k8s-test.svc/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediation?timeout=10s\)": dial tcp 10.96.26.250:443: connect: connection refused"`