### PR TITLE
Bugfix 1237 - update Remediation strategy description

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -38,7 +38,7 @@ type SelfNodeRemediationSpec struct {
 	//Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
 	//The first will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
 	//The latter will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26 or higher.
+	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
 	// +kubebuilder:default:="ResourceDeletion"
 	// +kubebuilder:validation:Enum=ResourceDeletion;OutOfServiceTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`

--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -35,10 +35,10 @@ type RemediationStrategyType string
 // SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
 type SelfNodeRemediationSpec struct {
 	//RemediationStrategy is the remediation method for unhealthy nodes.
-	//Currently "NodeDeletion" is deprecated and it could be either "ResourceDeletion" or "OutOfServiceTaint".
+	//Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
 	//The first will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
 	//The latter will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-	//that enables automatic deletion of pv-attached pods on failed nodes.
+	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26 or higher.
 	// +kubebuilder:default:="ResourceDeletion"
 	// +kubebuilder:validation:Enum=ResourceDeletion;OutOfServiceTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -43,12 +43,13 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes. Currently "NodeDeletion" is deprecated and it could be either
-                  "ResourceDeletion" or "OutOfServiceTaint". The first will iterate
-                  over all pods and VolumeAttachment related to the unhealthy node
-                  and delete them. The latter will add the out-of-service taint which
-                  is a new well-known taint "node.kubernetes.io/out-of-service" that
-                  enables automatic deletion of pv-attached pods on failed nodes.
+                  nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
+                  The first will iterate over all pods and VolumeAttachment related
+                  to the unhealthy node and delete them. The latter will add the out-of-service
+                  taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                  that enables automatic deletion of pv-attached pods on failed nodes,
+                  "OutOfServiceTaint" is only supported on clusters with k8s version
+                  1.26 or higher.
                 enum:
                 - ResourceDeletion
                 - OutOfServiceTaint

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -49,7 +49,7 @@ spec:
                   taint which is a new well-known taint "node.kubernetes.io/out-of-service"
                   that enables automatic deletion of pv-attached pods on failed nodes,
                   "OutOfServiceTaint" is only supported on clusters with k8s version
-                  1.26 or higher.
+                  1.26+ or OCP/OKD version 4.13+.
                 enum:
                 - ResourceDeletion
                 - OutOfServiceTaint

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -59,7 +59,7 @@ spec:
                           taint which is a new well-known taint "node.kubernetes.io/out-of-service"
                           that enables automatic deletion of pv-attached pods on failed
                           nodes, "OutOfServiceTaint" is only supported on clusters
-                          with k8s version 1.26 or higher.
+                          with k8s version 1.26+ or OCP/OKD version 4.13+.
                         enum:
                         - ResourceDeletion
                         - OutOfServiceTaint

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -52,13 +52,14 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes. Currently "NodeDeletion" is deprecated
-                          and it could be either "ResourceDeletion" or "OutOfServiceTaint".
-                          The first will iterate over all pods and VolumeAttachment
-                          related to the unhealthy node and delete them. The latter
-                          will add the out-of-service taint which is a new well-known
-                          taint "node.kubernetes.io/out-of-service" that enables automatic
-                          deletion of pv-attached pods on failed nodes.
+                          for unhealthy nodes. Currently, it could be either "ResourceDeletion"
+                          or "OutOfServiceTaint". The first will iterate over all
+                          pods and VolumeAttachment related to the unhealthy node
+                          and delete them. The latter will add the out-of-service
+                          taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                          that enables automatic deletion of pv-attached pods on failed
+                          nodes, "OutOfServiceTaint" is only supported on clusters
+                          with k8s version 1.26 or higher.
                         enum:
                         - ResourceDeletion
                         - OutOfServiceTaint

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -42,12 +42,13 @@ spec:
               remediationStrategy:
                 default: ResourceDeletion
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes. Currently "NodeDeletion" is deprecated and it could be either
-                  "ResourceDeletion" or "OutOfServiceTaint". The first will iterate
-                  over all pods and VolumeAttachment related to the unhealthy node
-                  and delete them. The latter will add the out-of-service taint which
-                  is a new well-known taint "node.kubernetes.io/out-of-service" that
-                  enables automatic deletion of pv-attached pods on failed nodes.
+                  nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
+                  The first will iterate over all pods and VolumeAttachment related
+                  to the unhealthy node and delete them. The latter will add the out-of-service
+                  taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                  that enables automatic deletion of pv-attached pods on failed nodes,
+                  "OutOfServiceTaint" is only supported on clusters with k8s version
+                  1.26 or higher.
                 enum:
                 - ResourceDeletion
                 - OutOfServiceTaint

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -48,7 +48,7 @@ spec:
                   taint which is a new well-known taint "node.kubernetes.io/out-of-service"
                   that enables automatic deletion of pv-attached pods on failed nodes,
                   "OutOfServiceTaint" is only supported on clusters with k8s version
-                  1.26 or higher.
+                  1.26+ or OCP/OKD version 4.13+.
                 enum:
                 - ResourceDeletion
                 - OutOfServiceTaint

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -58,7 +58,7 @@ spec:
                           taint which is a new well-known taint "node.kubernetes.io/out-of-service"
                           that enables automatic deletion of pv-attached pods on failed
                           nodes, "OutOfServiceTaint" is only supported on clusters
-                          with k8s version 1.26 or higher.
+                          with k8s version 1.26+ or OCP/OKD version 4.13+.
                         enum:
                         - ResourceDeletion
                         - OutOfServiceTaint

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -51,13 +51,14 @@ spec:
                       remediationStrategy:
                         default: ResourceDeletion
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes. Currently "NodeDeletion" is deprecated
-                          and it could be either "ResourceDeletion" or "OutOfServiceTaint".
-                          The first will iterate over all pods and VolumeAttachment
-                          related to the unhealthy node and delete them. The latter
-                          will add the out-of-service taint which is a new well-known
-                          taint "node.kubernetes.io/out-of-service" that enables automatic
-                          deletion of pv-attached pods on failed nodes.
+                          for unhealthy nodes. Currently, it could be either "ResourceDeletion"
+                          or "OutOfServiceTaint". The first will iterate over all
+                          pods and VolumeAttachment related to the unhealthy node
+                          and delete them. The latter will add the out-of-service
+                          taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+                          that enables automatic deletion of pv-attached pods on failed
+                          nodes, "OutOfServiceTaint" is only supported on clusters
+                          with k8s version 1.26 or higher.
                         enum:
                         - ResourceDeletion
                         - OutOfServiceTaint


### PR DESCRIPTION
- Removing the mention of "NodeDeletion" Strategy
- As part of [ECOPROJECT-1237](https://issues.redhat.com//browse/ECOPROJECT-1237) updating the description so it'll be clearer to the user as to why `OutOfServiceTaint` strategy can't be selected.

Note: This isn't planned for SNR 0.6.0