### PR TITLE
Ignore NHC timeout annotation on deletion of snr

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -814,7 +814,7 @@ func (r *SelfNodeRemediationReconciler) removeNoExecuteTaint(node *v1.Node) erro
 }
 
 func (r *SelfNodeRemediationReconciler) isStoppedByNHC(snr *v1alpha1.SelfNodeRemediation) bool {
-	if snr != nil && snr.Annotations != nil {
+	if snr != nil && snr.Annotations != nil && snr.DeletionTimestamp == nil{
 		_, isTimeoutIssued := snr.Annotations[nhcTimeOutAnnotation]
 		return isTimeoutIssued
 	}


### PR DESCRIPTION
This PR is meant to solve [ECOPROJECT-1243](https://issues.redhat.com//browse/ECOPROJECT-1243)

more context at slack conversation [here](https://redhat-internal.slack.com/archives/C03M5GKJNBA/p1681892288662789)