### PR TITLE
Use Ubuntu 22 as Hosted Runner in Github CI

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   push_to_registry:
     name: Build and push images to quay.io/medik8s
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -10,7 +10,7 @@ on: # on events
       - release-*
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ go mod init tmp ;\
 BIN_DIR=$$(dirname $(1)) ;\
 mkdir -p $$BIN_DIR ;\
 echo "Downloading $(2)" ;\
-GOBIN=$$BIN_DIR GOFLAGS='' go install $(2) ;\
+GOBIN=$$BIN_DIR GOFLAGS='' CGO_ENABLED=0 go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Follow up PR to #117 which will overcome the problem with **CGO_ENABLED=0** in controller-gen binary, when we update [hosted runner Ubuntu image for github-actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners) - `ubuntu-20.04` -> `ubuntu-22.04`.