### PR TITLE
setting go version for ci

### DIFF
--- a/ci-operator.yaml
+++ b/ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: rhel-8-release-golang-1.20-openshift-4.14


### PR DESCRIPTION
setting go version for ci, therefore making defining go version in ci redundant.