### PR TITLE
Removed '+patchMergeKey' and '+patchStrategy' markers.

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -67,8 +67,6 @@ type SelfNodeRemediationStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="conditions",xDescriptors="urn:alm:descriptor:com.tectonic.ui:conditions"
 	// Represents the observations of a SelfNodeRemediation's current state.
 	// Known .status.conditions.type are: "Processing"
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
 	// +optional


### PR DESCRIPTION
Removed '+patchMergeKey' and '+patchStrategy' markers.
These are for guiding strategic merge, which is not supported on CRDs.
According to https://github.com/kubernetes-sigs/gateway-api/issues/342 the markers +patchMergeKey' and '+patchStrategy' don't work on CRDs.
I've tested this by running `make generate` and `make manifests` and the resulting yaml CRD didn't change.
The desired effect in config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
```
type: array
                x-kubernetes-list-map-keys:
                - type
                x-kubernetes-list-type: map
```

is from '+listType' and '+listMapKey' as already applied.
