### PR TITLE
Fix prev PR meant to use golang version from SNR repo in CI

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: release
-  tag: golang-1.16
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/ci-operator.yaml
+++ b/ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: openshift
-  name: release
-  tag: rhel-8-release-golang-1.20-openshift-4.14


### PR DESCRIPTION
Fix for [PR](https://github.com/medik8s/self-node-remediation/pull/127)
- remove redundant ci-operator.yaml and update .ci-operator.yaml with correct golang version