### PR TITLE
Explicitly set MinVersion of TLS

### DIFF
--- a/pkg/certificates/credentials.go
+++ b/pkg/certificates/credentials.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const TLSMinVersion = tls.VersionTLS13
+
 func GetServerCredentialsFromCerts(certReader CertStorageReader) (credentials.TransportCredentials, error) {
 
 	keyPair, pool, err := prepareCredentials(certReader)
@@ -19,6 +21,7 @@ func GetServerCredentialsFromCerts(certReader CertStorageReader) (credentials.Tr
 		Certificates: []tls.Certificate{*keyPair},
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		ClientCAs:    pool,
+		MinVersion:   TLSMinVersion,
 	}), nil
 }
 
@@ -33,6 +36,7 @@ func GetClientCredentialsFromCerts(certReader CertStorageReader) (credentials.Tr
 		Certificates: []tls.Certificate{*keyPair},
 		RootCAs:      pool,
 		ServerName:   fixedCertIP.String(),
+		MinVersion:   TLSMinVersion,
 	}), nil
 }
 

--- a/pkg/controlplane/manager.go
+++ b/pkg/controlplane/manager.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/medik8s/self-node-remediation/pkg/certificates"
 	"github.com/medik8s/self-node-remediation/pkg/peers"
 	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
@@ -150,7 +151,10 @@ func (manager *Manager) isEndpointAccessible() bool {
 func (manager *Manager) isKubeletServiceRunning() bool {
 	url := fmt.Sprintf("https://%s:%s/pods", manager.nodeName, kubeletPort)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         certificates.TLSMinVersion,
+		},
 	}
 	httpClient := &http.Client{Transport: tr}
 


### PR DESCRIPTION
Currently, the default MinVersion value for TLS configuration is used,
which is TLS1.0 and considered insecure.

Explicitly set the MinVersion to a secure version of TLS.

closes: https://issues.redhat.com/browse/ECOPROJECT-1419

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
