### PR TITLE
Add log messages to trace OutOfServiceTaint remediation

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -871,6 +871,7 @@ func (r *SelfNodeRemediationReconciler) removeOutOfServiceTaint(node *v1.Node) e
 		r.logger.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", OutOfServiceTaint.Key, "taint effect", OutOfServiceTaint.Effect)
 		return err
 	}
+	r.logger.Info("outofservice taint removed", "new taints", node.Spec.Taints)
 	return nil
 }
 
@@ -882,6 +883,7 @@ func (r *SelfNodeRemediationReconciler) isResourceDeletionCompleted(node *v1.Nod
 	}
 	for _, pod := range pods.Items {
 		if pod.Spec.NodeName == node.Name && r.isPodTerminating(&pod) {
+			r.logger.Info("waiting for terminating pod ", "pod name", pod.Name, "phase", pod.Status.Phase)
 			return false
 		}
 	}
@@ -892,6 +894,7 @@ func (r *SelfNodeRemediationReconciler) isResourceDeletionCompleted(node *v1.Nod
 	}
 	for _, va := range volumeAttachments.Items {
 		if va.Spec.NodeName == node.Name {
+			r.logger.Info("waiting for deleting volumeAttachement", "name", va.Name)
 			return false
 		}
 	}


### PR DESCRIPTION
This PR is adding the following messages:

1. Add a message about deleting out-of-service taint 
2. Add a message about waiting for terminating pod when checking resource deletion
3. Add a message about waiting for deleting volumeAttachment when checking resource deletion

[ECOPROJECT-1241](https://issues.redhat.com/browse/ECOPROJECT-1241)