### PR TITLE
configure host port

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -114,6 +114,12 @@ type SelfNodeRemediationConfigSpec struct {
 	// It will be ignored when empty (which is the default).
 	EndpointHealthCheckUrl string `json:"endpointHealthCheckUrl,omitempty"`
 
+	// HostPort is used for internal communication between SNR agents.
+	// +optional
+	// +kubebuilder:default:=30001
+	// +kubebuilder:validation:Minimum=1
+	HostPort int `json:"hostPort,omitempty"`
+
 	// CustomDsTolerations allows to add custom tolerations snr agents that are running on the ds in order to support remediation for different types of nodes.
 	CustomDsTolerations []v1.Toleration `json:"customDsTolerations,omitempty"`
 }

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -103,6 +103,12 @@ spec:
                   will decide whether the node should be remediated or not. It will
                   be ignored when empty (which is the default).
                 type: string
+              hostPort:
+                default: 30001
+                description: HostPort is used for internal communication between SNR
+                  agents.
+                minimum: 1
+                type: integer
               isSoftwareRebootEnabled:
                 default: true
                 description: IsSoftwareRebootEnabled indicates whether self node remediation

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -101,6 +101,12 @@ spec:
                   will decide whether the node should be remediated or not. It will
                   be ignored when empty (which is the default).
                 type: string
+              hostPort:
+                default: 30001
+                description: HostPort is used for internal communication between SNR
+                  agents.
+                minimum: 1
+                type: integer
               isSoftwareRebootEnabled:
                 default: true
                 description: IsSoftwareRebootEnabled indicates whether self node remediation

--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -127,6 +127,7 @@ func (r *SelfNodeRemediationConfigReconciler) syncConfigDaemonSet(ctx context.Co
 	data.Data["PeerRequestTimeout"] = snrConfig.Spec.PeerRequestTimeout.Nanoseconds()
 	data.Data["MaxApiErrorThreshold"] = snrConfig.Spec.MaxApiErrorThreshold
 	data.Data["EndpointHealthCheckUrl"] = snrConfig.Spec.EndpointHealthCheckUrl
+	data.Data["HostPort"] = snrConfig.Spec.HostPort
 
 	timeToAssumeNodeRebooted := snrConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds
 	if timeToAssumeNodeRebooted == 0 {

--- a/controllers/selfnoderemediationconfig_controller_test.go
+++ b/controllers/selfnoderemediationconfig_controller_test.go
@@ -34,6 +34,7 @@ var _ = Describe("snrc controller Test", func() {
 		config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 123
 		config.Name = selfnoderemediationv1alpha1.ConfigCRName
 		config.Namespace = namespace
+		config.Spec.HostPort = 30111
 
 	})
 
@@ -64,6 +65,7 @@ var _ = Describe("snrc controller Test", func() {
 
 			Expect(createdConfig.Spec.WatchdogFilePath).To(Equal(config.Spec.WatchdogFilePath))
 			Expect(createdConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds).To(Equal(config.Spec.SafeTimeToAssumeNodeRebootedSeconds))
+			Expect(createdConfig.Spec.HostPort).To(Equal(30111))
 		})
 
 		It("Cert Secret should be created", func() {
@@ -89,6 +91,10 @@ var _ = Describe("snrc controller Test", func() {
 			Expect(len(ds.OwnerReferences)).To(Equal(1))
 			Expect(ds.OwnerReferences[0].Name).To(Equal(config.Name))
 			Expect(ds.OwnerReferences[0].Kind).To(Equal("SelfNodeRemediationConfig"))
+			Expect(len(container.Ports)).To(BeNumerically("==", 1))
+			port := container.Ports[0]
+			Expect(port.ContainerPort).To(BeEquivalentTo(30111))
+			Expect(port.HostPort).To(BeEquivalentTo(30111))
 		})
 		When("Configuration has customized tolerations", func() {
 			var expectedToleration corev1.Toleration

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -63,6 +63,8 @@ spec:
             value: {{.IsSoftwareRebootEnabled}}
           - name: END_POINT_HEALTH_CHECK_URL
             value: {{.EndpointHealthCheckUrl}}
+          - name: HOST_PORT
+            value: "{{.HostPort}}"
         image: {{.Image}}
         imagePullPolicy: Always
         volumeMounts:
@@ -73,8 +75,8 @@ spec:
           hostPID: true
         name: manager
         ports:
-        - containerPort: 30001
-          hostPort: 30001
+        - containerPort: {{.HostPort}}
+          hostPort: {{.HostPort}}
           name: self-n-r-port
           protocol: TCP
         resources:

--- a/main.go
+++ b/main.go
@@ -55,8 +55,7 @@ import (
 )
 
 const (
-	nodeNameEnvVar        = "MY_NODE_NAME"
-	peerHealthDefaultPort = 30001
+	nodeNameEnvVar = "MY_NODE_NAME"
 )
 
 var (
@@ -251,6 +250,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	peerDialTimeout := getDurEnvVarOrDie("PEER_DIAL_TIMEOUT")         //timeout for establishing connection to peer
 	peerRequestTimeout := getDurEnvVarOrDie("PEER_REQUEST_TIMEOUT")   //timeout for each peer request
 	timeToAssumeNodeRebooted := getDurEnvVarOrDie("TIME_TO_ASSUME_NODE_REBOOTED")
+	peerHealthDefaultPort := getIntEnvVarOrDie("HOST_PORT")
 
 	safeRebootCalc := reboot.NewSafeTimeCalculator(mgr.GetClient(), wd, maxErrorThreshold, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, timeToAssumeNodeRebooted)
 	if err = mgr.Add(safeRebootCalc); err != nil {


### PR DESCRIPTION
[ECOPROJECT-1581](https://issues.redhat.com//browse/ECOPROJECT-1581)
Currently the hostPort: 30001 is fixed by the operator and is no possible to change, making it impossible for pods to deploy if that port is already in use.
This PR makes the port configurable.