### PR TITLE
config value of safe time to reboot was calculated wrongly

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -25,10 +25,10 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 const (
-	ConfigCRName                          = "self-node-remediation-config"
-	defaultWatchdogPath                   = "/dev/watchdog"
-	defaultSafetToAssumeNodeRebootTimeout = 180
-	defaultIsSoftwareRebootEnabled        = true
+	ConfigCRName                         = "self-node-remediation-config"
+	defaultWatchdogPath                  = "/dev/watchdog"
+	DefaultSafeToAssumeNodeRebootTimeout = 180
+	defaultIsSoftwareRebootEnabled       = true
 )
 
 // SelfNodeRemediationConfigSpec defines the desired state of SelfNodeRemediationConfig
@@ -156,7 +156,7 @@ func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 		ObjectMeta: metav1.ObjectMeta{Name: ConfigCRName},
 		Spec: SelfNodeRemediationConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,
-			SafeTimeToAssumeNodeRebootedSeconds: defaultSafetToAssumeNodeRebootTimeout,
+			SafeTimeToAssumeNodeRebootedSeconds: DefaultSafeToAssumeNodeRebootTimeout,
 			IsSoftwareRebootEnabled:             defaultIsSoftwareRebootEnabled,
 		},
 	}

--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -128,11 +128,11 @@ func (r *SelfNodeRemediationConfigReconciler) syncConfigDaemonSet(ctx context.Co
 	data.Data["MaxApiErrorThreshold"] = snrConfig.Spec.MaxApiErrorThreshold
 	data.Data["EndpointHealthCheckUrl"] = snrConfig.Spec.EndpointHealthCheckUrl
 
-	timeToAssumeNodeRebooted := snrConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds
-	if timeToAssumeNodeRebooted == 0 {
-		timeToAssumeNodeRebooted = 180
+	safeTimeToAssumeNodeRebootedSeconds := snrConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds
+	if safeTimeToAssumeNodeRebootedSeconds == 0 {
+		safeTimeToAssumeNodeRebootedSeconds = selfnoderemediationv1alpha1.DefaultSafeToAssumeNodeRebootTimeout
 	}
-	data.Data["TimeToAssumeNodeRebooted"] = fmt.Sprintf("\"%d\"", timeToAssumeNodeRebooted)
+	data.Data["TimeToAssumeNodeRebooted"] = fmt.Sprintf("\"%d\"", safeTimeToAssumeNodeRebootedSeconds)
 
 	data.Data["IsSoftwareRebootEnabled"] = fmt.Sprintf("\"%t\"", snrConfig.Spec.IsSoftwareRebootEnabled)
 

--- a/main.go
+++ b/main.go
@@ -250,9 +250,9 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	apiServerTimeout := getDurEnvVarOrDie("API_SERVER_TIMEOUT")       //timeout for each api-connectivity check
 	peerDialTimeout := getDurEnvVarOrDie("PEER_DIAL_TIMEOUT")         //timeout for establishing connection to peer
 	peerRequestTimeout := getDurEnvVarOrDie("PEER_REQUEST_TIMEOUT")   //timeout for each peer request
-	timeToAssumeNodeRebooted := getDurEnvVarOrDie("TIME_TO_ASSUME_NODE_REBOOTED")
+	timeToAssumeNodeRebootedInSeconds := getIntEnvVarOrDie("TIME_TO_ASSUME_NODE_REBOOTED")
 
-	safeRebootCalc := reboot.NewSafeTimeCalculator(mgr.GetClient(), wd, maxErrorThreshold, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, timeToAssumeNodeRebooted)
+	safeRebootCalc := reboot.NewSafeTimeCalculator(mgr.GetClient(), wd, maxErrorThreshold, apiCheckInterval, apiServerTimeout, peerDialTimeout, peerRequestTimeout, time.Duration(timeToAssumeNodeRebootedInSeconds)*time.Second)
 	if err = mgr.Add(safeRebootCalc); err != nil {
 		setupLog.Error(err, "failed to add safe reboot time calculator to the manager")
 		os.Exit(1)


### PR DESCRIPTION
[ECOPROJECT-1630](https://issues.redhat.com//browse/ECOPROJECT-1630)
safeTimeToAssumeNodeRebootedSeconds doesn't impact actual time of node returning to health.