### PR TITLE
Handle large cluster load

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -157,7 +157,7 @@ func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	if r.IsAgent() {
 		if req.Name != r.MyNodeName {
-			r.logger.Info("agent pod skipping remediation because node belongs to a different agent")
+			r.logger.Info("agent pod skipping remediation because node belongs to a different agent", "Agent node name", r.MyNodeName, "Remediated node name", req.Name)
 			return ctrl.Result{}, nil
 		}
 		r.logger.Info("agent pod starting remediation on owned node")

--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	pkgerrors "github.com/pkg/errors"
@@ -37,6 +38,7 @@ import (
 	selfnoderemediationv1alpha1 "github.com/medik8s/self-node-remediation/api/v1alpha1"
 	"github.com/medik8s/self-node-remediation/pkg/apply"
 	"github.com/medik8s/self-node-remediation/pkg/certificates"
+	"github.com/medik8s/self-node-remediation/pkg/reboot"
 	"github.com/medik8s/self-node-remediation/pkg/render"
 )
 
@@ -47,11 +49,12 @@ const (
 // SelfNodeRemediationConfigReconciler reconciles a SelfNodeRemediationConfig object
 type SelfNodeRemediationConfigReconciler struct {
 	client.Client
-	Log               logr.Logger
-	Scheme            *runtime.Scheme
-	InstallFileFolder string
-	DefaultPpcCreator func(c client.Client) error
-	Namespace         string
+	Log                       logr.Logger
+	Scheme                    *runtime.Scheme
+	InstallFileFolder         string
+	DefaultPpcCreator         func(c client.Client) error
+	Namespace                 string
+	ManagerSafeTimeCalculator reboot.SafeTimeCalculator
 }
 
 //+kubebuilder:rbac:groups=self-node-remediation.medik8s.io,resources=selfnoderemediationconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -94,6 +97,8 @@ func (r *SelfNodeRemediationConfigReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, err
 	}
 
+	//sync manager reconciler
+	r.ManagerSafeTimeCalculator.SetTimeToAssumeNodeRebooted(time.Duration(config.Spec.SafeTimeToAssumeNodeRebootedSeconds) * time.Second)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/tests/config/suite_test.go
+++ b/controllers/tests/config/suite_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testconfig
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	selfnoderemediationv1alpha1 "github.com/medik8s/self-node-remediation/api/v1alpha1"
+	"github.com/medik8s/self-node-remediation/controllers"
+	"github.com/medik8s/self-node-remediation/controllers/tests/shared"
+	"github.com/medik8s/self-node-remediation/pkg/apicheck"
+	"github.com/medik8s/self-node-remediation/pkg/certificates"
+	"github.com/medik8s/self-node-remediation/pkg/peers"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var testEnv *envtest.Environment
+var unhealthyNode, peerNode = &v1.Node{}, &v1.Node{}
+var cancelFunc context.CancelFunc
+var k8sClient *shared.K8sClientWrapper
+var certReader certificates.CertStorageReader
+var managerReconciler *controllers.SelfNodeRemediationReconciler
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SNR Config Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("../../..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = selfnoderemediationv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	k8sClient = &shared.K8sClientWrapper{
+		Client:           k8sManager.GetClient(),
+		Reader:           k8sManager.GetAPIReader(),
+		VaFailureMessage: "simulation of client error for VA",
+	}
+	Expect(k8sClient).ToNot(BeNil())
+
+	nsToCreate := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: shared.Namespace,
+		},
+	}
+
+	Expect(k8sClient.Create(context.Background(), nsToCreate)).To(Succeed())
+	Expect(err).ToNot(HaveOccurred())
+	mockManagerCalculator := &mockCalculator{isAgent: false}
+	err = (&controllers.SelfNodeRemediationConfigReconciler{
+		Client:                    k8sManager.GetClient(),
+		Log:                       ctrl.Log.WithName("controllers").WithName("self-node-remediation-config-controller"),
+		InstallFileFolder:         "../../../install/",
+		Scheme:                    scheme.Scheme,
+		Namespace:                 shared.Namespace,
+		ManagerSafeTimeCalculator: mockManagerCalculator,
+	}).SetupWithManager(k8sManager)
+
+	// peers need their own node on start
+	unhealthyNode = getNode(shared.UnhealthyNodeName)
+	Expect(k8sClient.Create(context.Background(), unhealthyNode)).To(Succeed(), "failed to create unhealthy node")
+
+	peerNode = getNode(shared.PeerNodeName)
+	Expect(k8sClient.Create(context.Background(), peerNode)).To(Succeed(), "failed to create peer node")
+
+	peerApiServerTimeout := 5 * time.Second
+	peers := peers.New(shared.UnhealthyNodeName, shared.PeerUpdateInterval, k8sClient, ctrl.Log.WithName("peers"), peerApiServerTimeout)
+	err = k8sManager.Add(peers)
+	Expect(err).ToNot(HaveOccurred())
+
+	certReader = certificates.NewSecretCertStorage(k8sClient, ctrl.Log.WithName("SecretCertStorage"), shared.Namespace)
+	apiConnectivityCheckConfig := &apicheck.ApiConnectivityCheckConfig{
+		Log:                ctrl.Log.WithName("api-check"),
+		MyNodeName:         shared.UnhealthyNodeName,
+		CheckInterval:      shared.ApiCheckInterval,
+		MaxErrorsThreshold: shared.MaxErrorThreshold,
+		Peers:              peers,
+		Cfg:                cfg,
+		CertReader:         certReader,
+	}
+	apiCheck := apicheck.New(apiConnectivityCheckConfig, nil)
+	err = k8sManager.Add(apiCheck)
+	Expect(err).ToNot(HaveOccurred())
+
+	restoreNodeAfter := 5 * time.Second
+	mockAgentCalculator := &mockCalculator{isAgent: true}
+	// reconciler for unhealthy node
+	err = (&controllers.SelfNodeRemediationReconciler{
+		Client:             k8sClient,
+		Log:                ctrl.Log.WithName("controllers").WithName("self-node-remediation-controller").WithName("unhealthy node"),
+		MyNodeName:         shared.UnhealthyNodeName,
+		RestoreNodeAfter:   restoreNodeAfter,
+		SafeTimeCalculator: mockAgentCalculator,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// reconciler for peer node
+	err = (&controllers.SelfNodeRemediationReconciler{
+		Client:             k8sClient,
+		Log:                ctrl.Log.WithName("controllers").WithName("self-node-remediation-controller").WithName("peer node"),
+		MyNodeName:         shared.PeerNodeName,
+		RestoreNodeAfter:   restoreNodeAfter,
+		SafeTimeCalculator: mockAgentCalculator,
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	// reconciler for manager on peer node
+	managerReconciler = &controllers.SelfNodeRemediationReconciler{
+		Client:             k8sClient,
+		Log:                ctrl.Log.WithName("controllers").WithName("self-node-remediation-controller").WithName("manager node"),
+		MyNodeName:         shared.PeerNodeName,
+		RestoreNodeAfter:   restoreNodeAfter,
+		SafeTimeCalculator: mockManagerCalculator,
+	}
+	err = managerReconciler.SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	var ctx context.Context
+	ctx, cancelFunc = context.WithCancel(ctrl.SetupSignalHandler())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+
+})
+
+func getNode(name string) *v1.Node {
+	node := &v1.Node{}
+	node.Name = name
+	node.Labels = make(map[string]string)
+	node.Labels["kubernetes.io/hostname"] = name
+
+	return node
+}
+
+var _ = AfterSuite(func() {
+	cancelFunc()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+
+})
+
+type mockCalculator struct {
+	mockTimeToAssumeNodeRebooted time.Duration
+	isAgent                      bool
+}
+
+func (m *mockCalculator) GetTimeToAssumeNodeRebooted() time.Duration {
+	return m.mockTimeToAssumeNodeRebooted
+}
+
+func (m *mockCalculator) SetTimeToAssumeNodeRebooted(timeToAssumeNodeRebooted time.Duration) {
+	m.mockTimeToAssumeNodeRebooted = timeToAssumeNodeRebooted
+}
+
+func (m *mockCalculator) IsAgent() bool {
+	return m.isAgent
+}
+
+//goland:noinspection GoUnusedParameter
+func (m *mockCalculator) Start(ctx context.Context) error {
+	return nil
+}

--- a/controllers/tests/shared/shared.go
+++ b/controllers/tests/shared/shared.go
@@ -1,0 +1,60 @@
+package shared
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	PeerUpdateInterval = 30 * time.Second
+	ApiCheckInterval   = 1 * time.Second
+	MaxErrorThreshold  = 1
+	Namespace          = "self-node-remediation"
+	UnhealthyNodeName  = "node1"
+	PeerNodeName       = "node2"
+)
+
+type K8sClientWrapper struct {
+	client.Client
+	Reader                  client.Reader
+	ShouldSimulateFailure   bool
+	ShouldSimulateVaFailure bool
+	VaFailureMessage        string
+}
+
+type MockCalculator struct {
+	MockTimeToAssumeNodeRebooted time.Duration
+	IsAgentVar                   bool
+}
+
+func (kcw *K8sClientWrapper) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if kcw.ShouldSimulateFailure {
+		return errors.New("simulation of client error")
+	} else if kcw.ShouldSimulateVaFailure {
+		if _, ok := list.(*storagev1.VolumeAttachmentList); ok {
+			return errors.New(kcw.VaFailureMessage)
+		}
+	}
+	return kcw.Client.List(ctx, list, opts...)
+}
+
+func (m *MockCalculator) GetTimeToAssumeNodeRebooted() time.Duration {
+	return m.MockTimeToAssumeNodeRebooted
+}
+
+func (m *MockCalculator) SetTimeToAssumeNodeRebooted(timeToAssumeNodeRebooted time.Duration) {
+	m.MockTimeToAssumeNodeRebooted = timeToAssumeNodeRebooted
+}
+
+func (m *MockCalculator) IsAgent() bool {
+	return m.IsAgentVar
+}
+
+//goland:noinspection GoUnusedParameter
+func (m *MockCalculator) Start(ctx context.Context) error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -236,6 +236,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	if myNodeName == "" {
 		setupLog.Error(errors.New("failed to get own node name"), "node name was empty",
 			"env var name", nodeNameEnvVar)
+		os.Exit(1)
 	}
 
 	ns, err := utils.GetDeploymentNamespace()

--- a/pkg/peerhealth/suite_test.go
+++ b/pkg/peerhealth/suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	selfnoderemediationv1alpha1 "github.com/medik8s/self-node-remediation/api/v1alpha1"
 	"github.com/medik8s/self-node-remediation/controllers"
+	"github.com/medik8s/self-node-remediation/controllers/tests/shared"
 )
 
 func TestPeerHealth(t *testing.T) {
@@ -73,9 +74,10 @@ var _ = BeforeSuite(func() {
 
 	// we need a reconciler for getting last SNR namespace
 	snrReconciler = &controllers.SelfNodeRemediationReconciler{
-		Client:     k8sClient,
-		Log:        ctrl.Log.WithName("controllers").WithName("self-node-remediation-controller").WithName("peer node"),
-		MyNodeName: nodeName,
+		Client:             k8sClient,
+		Log:                ctrl.Log.WithName("controllers").WithName("self-node-remediation-controller").WithName("peer node"),
+		MyNodeName:         nodeName,
+		SafeTimeCalculator: &shared.MockCalculator{MockTimeToAssumeNodeRebooted: time.Minute * 3, IsAgentVar: true},
 	}
 	err = snrReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/reboot/calculator.go
+++ b/pkg/reboot/calculator.go
@@ -107,8 +107,8 @@ func (s *safeTimeCalculator) calcMinTimeAssumeRebooted() error {
 	s.minTimeToAssumeNodeRebooted = minTime
 
 	if s.timeToAssumeNodeRebooted < minTime {
-		err := fmt.Errorf("snr agent can't start requested value for timeToAssumeNodeRebooted is too low")
-		s.log.Error(err, err.Error(), "requested timeToAssumeNodeRebooted", s.timeToAssumeNodeRebooted, "timeToAssumeNodeRebooted minimal valid value", minTime)
+		err := fmt.Errorf("snr agent can't start: the requested value for SafeTimeToAssumeNodeRebootedSeconds is too low")
+		s.log.Error(err, err.Error(), "requested SafeTimeToAssumeNodeRebootedSeconds", s.timeToAssumeNodeRebooted, "minimal calculated value for SafeTimeToAssumeNodeRebootedSeconds", minTime)
 		return err
 	}
 	return nil

--- a/pkg/reboot/rebooter_test.go
+++ b/pkg/reboot/rebooter_test.go
@@ -20,8 +20,8 @@ var _ = Describe("Rebooter tests", func() {
 
 	Describe("Crash on start", func() {
 		BeforeEach(func() {
-			wd, _ := watchdog.NewFake(false)
-			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot, nil}
+			wd := watchdog.NewFake(false)
+			rebooter = &watchdogRebooter{wd, ctrl.Log.WithName("fake rebooter"), fakeSoftwareReboot}
 
 		})
 

--- a/pkg/watchdog/fake.go
+++ b/pkg/watchdog/fake.go
@@ -11,30 +11,28 @@ const (
 	fakeTimeout = 1 * time.Second
 )
 
-var FakeWD *fakeWatchdog
-
-// fakeWatchdog provides the fake implementation of the watchdogImpl interface for tests
-type fakeWatchdog struct {
+// fakeWatchdogImpl provides the fake implementation of the watchdogImpl interface for tests
+type fakeWatchdogImpl struct {
 	IsStartSuccessful bool
 }
 
-func NewFake(isStartSuccessful bool) (Watchdog, error) {
-	FakeWD = &fakeWatchdog{IsStartSuccessful: isStartSuccessful}
-	return newSynced(ctrl.Log.WithName("fake watchdog"), FakeWD), nil
+func NewFake(isStartSuccessful bool) Watchdog {
+	fakeWDImpl := &fakeWatchdogImpl{IsStartSuccessful: isStartSuccessful}
+	return newSynced(ctrl.Log.WithName("fake watchdog"), fakeWDImpl)
 }
 
-func (f *fakeWatchdog) start() (*time.Duration, error) {
+func (f *fakeWatchdogImpl) start() (*time.Duration, error) {
 	if !f.IsStartSuccessful {
-		return nil, errors.New("fakeWatchdog crash on start")
+		return nil, errors.New("fakeWatchdogImpl crash on start")
 	}
 	t := fakeTimeout
 	return &t, nil
 }
 
-func (f *fakeWatchdog) feed() error {
+func (f *fakeWatchdogImpl) feed() error {
 	return nil
 }
 
-func (f *fakeWatchdog) disarm() error {
+func (f *fakeWatchdogImpl) disarm() error {
 	return nil
 }


### PR DESCRIPTION
[ECOPROJECT-1261](https://issues.redhat.com//browse/ECOPROJECT-1261)
At the moment, upon a remediation detected by SNR all DaemSets (i.e all SNR agent - each on every node) will perform APIServer calls as part of SNR remediation process.
In large clusters that can cause an overload on the APIServer.

We need to consider a solution to reduce the amount of APIServer call in order to minimize that risk.