### PR TITLE
[WIP] Provide TLS Certificate to kubelet service status request

### DIFF
--- a/main.go
+++ b/main.go
@@ -311,7 +311,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 		MaxTimeForNoPeersResponse: reboot.MaxTimeForNoPeersResponse,
 	}
 
-	controlPlaneManager := controlplane.NewManager(myNodeName, mgr.GetClient())
+	controlPlaneManager := controlplane.NewManager(myNodeName, mgr.GetClient(), certReader)
 
 	if err = mgr.Add(controlPlaneManager); err != nil {
 		setupLog.Error(err, "failed to add controlPlane remediation manager to setup manager")

--- a/pkg/certificates/credentials.go
+++ b/pkg/certificates/credentials.go
@@ -12,7 +12,7 @@ const TLSMinVersion = tls.VersionTLS13
 
 func GetServerCredentialsFromCerts(certReader CertStorageReader) (credentials.TransportCredentials, error) {
 
-	keyPair, pool, err := prepareCredentials(certReader)
+	keyPair, pool, err := PrepareCredentials(certReader)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func GetServerCredentialsFromCerts(certReader CertStorageReader) (credentials.Tr
 
 func GetClientCredentialsFromCerts(certReader CertStorageReader) (credentials.TransportCredentials, error) {
 
-	keyPair, pool, err := prepareCredentials(certReader)
+	keyPair, pool, err := PrepareCredentials(certReader)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func GetClientCredentialsFromCerts(certReader CertStorageReader) (credentials.Tr
 	}), nil
 }
 
-func prepareCredentials(certReader CertStorageReader) (*tls.Certificate, *x509.CertPool, error) {
+func PrepareCredentials(certReader CertStorageReader) (*tls.Certificate, *x509.CertPool, error) {
 	caPem, certPem, keyPem, err := certReader.GetCerts()
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This change enhances the security of the kubelet service request in the
control plane manager by providing a TLS certificate when making the
request.

- Provide a CertStorageReader to the Manager
- Re-use PrepareCredentials function from certificates package to create
  the proper certificates
- Change TLSConfig providing Certificates and setting InsecureSkipVerify
  to false

see https://issues.redhat.com/browse/ECOPROJECT-1421
