### PR TITLE
Do not create PeerHealth new client without credentials

### DIFF
--- a/pkg/peerhealth/client.go
+++ b/pkg/peerhealth/client.go
@@ -2,6 +2,7 @@ package peerhealth
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -22,7 +23,7 @@ func NewClient(serverAddr string, peerDialTimeout time.Duration, log logr.Logger
 	if clientCreds != nil {
 		opts = append(opts, grpc.WithTransportCredentials(clientCreds))
 	} else {
-		opts = append(opts, grpc.WithInsecure())
+		return nil, fmt.Errorf("client credential is nil")
 	}
 
 	// this option implies WithBlock()


### PR DESCRIPTION
Currently if peerhealth.NewClient is called with no
credentials.TransportCredentials it uses a DialOption which disables
transport security for this ClientConn.

Considering also the in the current code base it is not possible to
reach this point without valid credentials, this commit removes the
usage of such DialOption and returns with error instead for security
reasons.
