### PR TITLE
remove VA deletion

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -339,7 +339,7 @@ func (r *SelfNodeRemediationReconciler) deleteResources(node *v1.Node) error {
 
 	namespaces := v1.NamespaceList{}
 	if err := r.Client.List(context.Background(), &namespaces); err != nil {
-		r.logger.Error(err, "failed to list namespaces", err)
+		r.logger.Error(err, "failed to list namespaces")
 		return err
 	}
 
@@ -352,24 +352,6 @@ func (r *SelfNodeRemediationReconciler) deleteResources(node *v1.Node) error {
 		if err != nil {
 			r.logger.Error(err, "failed to delete pods of unhealthy node", "namespace", ns.Name)
 			return err
-		}
-	}
-
-	volumeAttachments := &storagev1.VolumeAttachmentList{}
-	if err := r.Client.List(context.Background(), volumeAttachments); err != nil {
-		r.logger.Error(err, "failed to get volumeAttachments list")
-		return err
-	}
-	forceDeleteOption := &client.DeleteOptions{
-		GracePeriodSeconds: &zero,
-	}
-	for _, va := range volumeAttachments.Items {
-		if va.Spec.NodeName == node.Name {
-			err := r.Client.Delete(context.Background(), &va, forceDeleteOption)
-			if err != nil {
-				r.logger.Error(err, "failed to delete volumeAttachment", "name", va.Name)
-				return err
-			}
 		}
 	}
 

--- a/controllers/tests/config/suite_test.go
+++ b/controllers/tests/config/suite_test.go
@@ -82,9 +82,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = &shared.K8sClientWrapper{
-		Client:           k8sManager.GetClient(),
-		Reader:           k8sManager.GetAPIReader(),
-		VaFailureMessage: "simulation of client error for VA",
+		Client: k8sManager.GetClient(),
+		Reader: k8sManager.GetAPIReader(),
 	}
 	Expect(k8sClient).ToNot(BeNil())
 

--- a/controllers/tests/controller/suite_test.go
+++ b/controllers/tests/controller/suite_test.go
@@ -96,9 +96,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	k8sClient = &shared.K8sClientWrapper{
-		Client:           k8sManager.GetClient(),
-		Reader:           k8sManager.GetAPIReader(),
-		VaFailureMessage: "simulation of client error for VA",
+		Client:                  k8sManager.GetClient(),
+		Reader:                  k8sManager.GetAPIReader(),
+		SimulatedFailureMessage: "simulation of client error for delete when listing namespace",
 	}
 	Expect(k8sClient).ToNot(BeNil())
 

--- a/controllers/tests/shared/shared.go
+++ b/controllers/tests/shared/shared.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	storagev1 "k8s.io/api/storage/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -20,10 +20,10 @@ const (
 
 type K8sClientWrapper struct {
 	client.Client
-	Reader                  client.Reader
-	ShouldSimulateFailure   bool
-	ShouldSimulateVaFailure bool
-	VaFailureMessage        string
+	Reader                         client.Reader
+	ShouldSimulateFailure          bool
+	ShouldSimulatePodDeleteFailure bool
+	SimulatedFailureMessage        string
 }
 
 type MockCalculator struct {
@@ -34,9 +34,9 @@ type MockCalculator struct {
 func (kcw *K8sClientWrapper) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	if kcw.ShouldSimulateFailure {
 		return errors.New("simulation of client error")
-	} else if kcw.ShouldSimulateVaFailure {
-		if _, ok := list.(*storagev1.VolumeAttachmentList); ok {
-			return errors.New(kcw.VaFailureMessage)
+	} else if kcw.ShouldSimulatePodDeleteFailure {
+		if _, ok := list.(*corev1.NamespaceList); ok {
+			return errors.New(kcw.SimulatedFailureMessage)
 		}
 	}
 	return kcw.Client.List(ctx, list, opts...)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/go-ping/ping v1.1.0
-	github.com/medik8s/common v1.2.0
+	github.com/medik8s/common v1.9.0
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.2.0 h1:xgQOijD3rEn+PfCd4lJuV3WFdt5QA6SIaqF01rRp2as=
-github.com/medik8s/common v1.2.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
+github.com/medik8s/common v1.9.0 h1:nMMffmj+e0l0xRB0RfpsbdDpW9upXU2MFeGGADJlwyE=
+github.com/medik8s/common v1.9.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
 github.com/mitchellh/copystructure v1.1.2 h1:Th2TIvG1+6ma3e/0/bopBKohOTY7s4dA8V2q4EUcBJ0=
 github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=

--- a/vendor/github.com/medik8s/common/pkg/resources/resources.go
+++ b/vendor/github.com/medik8s/common/pkg/resources/resources.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeletePods deletes all the pods from the node
+func DeletePods(ctx context.Context, r client.Client, nodeName string) error {
+	log := ctrl.Log.WithName("commons-resource")
+	zero := int64(0)
+	backgroundDeletePolicy := metav1.DeletePropagationBackground
+
+	deleteOptions := &client.DeleteAllOfOptions{
+		ListOptions: client.ListOptions{
+			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}),
+			Namespace:     "",
+			Limit:         0,
+		},
+		DeleteOptions: client.DeleteOptions{
+			GracePeriodSeconds: &zero,
+			PropagationPolicy:  &backgroundDeletePolicy,
+		},
+	}
+
+	namespaces := corev1.NamespaceList{}
+	if err := r.List(ctx, &namespaces); err != nil {
+		log.Error(err, "failed to list namespaces")
+		return err
+	}
+
+	log.Info("starting to delete pods", "node name", nodeName)
+
+	pod := &corev1.Pod{}
+	for _, ns := range namespaces.Items {
+		deleteOptions.Namespace = ns.Name
+		err := r.DeleteAllOf(ctx, pod, deleteOptions)
+		if err != nil {
+			log.Error(err, "failed to delete pods of node", "namespace", ns.Name)
+			return err
+		}
+	}
+
+	log.Info("done deleting pods", "node name", nodeName)
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,10 +107,11 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.2.0
+# github.com/medik8s/common v1.9.0
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/nodes
+github.com/medik8s/common/pkg/resources
 # github.com/mitchellh/copystructure v1.1.2
 ## explicit; go 1.15
 github.com/mitchellh/copystructure


### PR DESCRIPTION
[ECOPROJECT-1748](https://issues.redhat.com//browse/ECOPROJECT-1748)
VA should not be deleted by SNR. kube-control-manager (KCM) detects the pod deletion and automatically detaches the VAs which are not connected to any pod, forcefully deleting the VA has the risk of interfering with the process of detaching the VAs.