### PR TITLE
Automatic remediation strategy

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -24,7 +24,7 @@ const (
 	AutomaticRemediationStrategy         = RemediationStrategyType("Automatic")
 	ResourceDeletionRemediationStrategy  = RemediationStrategyType("ResourceDeletion")
 	OutOfServiceTaintRemediationStrategy = RemediationStrategyType("OutOfServiceTaint")
-	DefaultRemediationStrategy           = ResourceDeletionRemediationStrategy
+	DefaultRemediationStrategy           = AutomaticRemediationStrategy
 	// ProcessingConditionType is the condition type used to signal NHC the remediation status
 	ProcessingConditionType = "Processing"
 	// SucceededConditionType is the condition type used to signal NHC whether the remediation was successful or not

--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	AutomaticRemediationStrategy         = RemediationStrategyType("Automatic")
 	ResourceDeletionRemediationStrategy  = RemediationStrategyType("ResourceDeletion")
 	OutOfServiceTaintRemediationStrategy = RemediationStrategyType("OutOfServiceTaint")
 	// ProcessingConditionType is the condition type used to signal NHC the remediation status
@@ -41,8 +42,8 @@ type SelfNodeRemediationSpec struct {
 	//The first will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
 	//The latter will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
 	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
-	// +kubebuilder:default:="ResourceDeletion"
-	// +kubebuilder:validation:Enum=ResourceDeletion;OutOfServiceTaint
+	// +kubebuilder:default:="Automatic"
+	// +kubebuilder:validation:Enum=Automatic;ResourceDeletion;OutOfServiceTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`
 }
 

--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -42,7 +42,7 @@ type SelfNodeRemediationSpec struct {
 	//Currently, it could be either "Automatic", "OutOfServiceTaint" or "ResourceDeletion".
 	//ResourceDeletion will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
 	//OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+	//that enables automatic deletion of pv-attached pods on failed nodes, "out-of-service" taint is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
 	// Automatic will choose the most appropriate strategy during runtime.
 	// +kubebuilder:default:="Automatic"
 	// +kubebuilder:validation:Enum=Automatic;ResourceDeletion;OutOfServiceTaint

--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -38,10 +38,11 @@ type RemediationStrategyType string
 // SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
 type SelfNodeRemediationSpec struct {
 	//RemediationStrategy is the remediation method for unhealthy nodes.
-	//Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
-	//The first will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
-	//The latter will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
+	//Currently, it could be either "Automatic", "OutOfServiceTaint" or "ResourceDeletion".
+	//ResourceDeletion will iterate over all pods and VolumeAttachment related to the unhealthy node and delete them.
+	//OutOfServiceTaint will add the out-of-service taint which is a new well-known taint "node.kubernetes.io/out-of-service"
 	//that enables automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint" is only supported on clusters with k8s version 1.26+ or OCP/OKD version 4.13+.
+	// Automatic will choose the most appropriate strategy during runtime.
 	// +kubebuilder:default:="Automatic"
 	// +kubebuilder:validation:Enum=Automatic;ResourceDeletion;OutOfServiceTaint
 	RemediationStrategy RemediationStrategyType `json:"remediationStrategy,omitempty"`

--- a/api/v1alpha1/selfnoderemediationtemplate_types.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_types.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	resourceDeletionTemplateName = "self-node-remediation-resource-deletion-template"
+	automaticTemplateName = "self-node-remediation-automatic-strategy-template"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -74,12 +74,12 @@ func NewRemediationTemplates() []*SelfNodeRemediationTemplate {
 	return []*SelfNodeRemediationTemplate{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: resourceDeletionTemplateName,
+				Name: automaticTemplateName,
 			},
 			Spec: SelfNodeRemediationTemplateSpec{
 				Template: SelfNodeRemediationTemplateResource{
 					Spec: SelfNodeRemediationSpec{
-						RemediationStrategy: ResourceDeletionRemediationStrategy,
+						RemediationStrategy: AutomaticRemediationStrategy,
 					},
 				},
 			},

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -43,13 +43,15 @@ spec:
               remediationStrategy:
                 default: Automatic
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
-                  The first will iterate over all pods and VolumeAttachment related
-                  to the unhealthy node and delete them. The latter will add the out-of-service
-                  taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-                  that enables automatic deletion of pv-attached pods on failed nodes,
-                  "OutOfServiceTaint" is only supported on clusters with k8s version
-                  1.26+ or OCP/OKD version 4.13+.
+                  nodes. Currently, it could be either "Automatic", "OutOfServiceTaint"
+                  or "ResourceDeletion". ResourceDeletion will iterate over all pods
+                  and VolumeAttachment related to the unhealthy node and delete them.
+                  OutOfServiceTaint will add the out-of-service taint which is a new
+                  well-known taint "node.kubernetes.io/out-of-service" that enables
+                  automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
+                  is only supported on clusters with k8s version 1.26+ or OCP/OKD
+                  version 4.13+. Automatic will choose the most appropriate strategy
+                  during runtime.
                 enum:
                 - Automatic
                 - ResourceDeletion

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -48,8 +48,8 @@ spec:
                   and VolumeAttachment related to the unhealthy node and delete them.
                   OutOfServiceTaint will add the out-of-service taint which is a new
                   well-known taint "node.kubernetes.io/out-of-service" that enables
-                  automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
-                  is only supported on clusters with k8s version 1.26+ or OCP/OKD
+                  automatic deletion of pv-attached pods on failed nodes, "out-of-service"
+                  taint is only supported on clusters with k8s version 1.26+ or OCP/OKD
                   version 4.13+. Automatic will choose the most appropriate strategy
                   during runtime.
                 enum:

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -41,7 +41,7 @@ spec:
             description: SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
             properties:
               remediationStrategy:
-                default: ResourceDeletion
+                default: Automatic
                 description: RemediationStrategy is the remediation method for unhealthy
                   nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
                   The first will iterate over all pods and VolumeAttachment related
@@ -51,6 +51,7 @@ spec:
                   "OutOfServiceTaint" is only supported on clusters with k8s version
                   1.26+ or OCP/OKD version 4.13+.
                 enum:
+                - Automatic
                 - ResourceDeletion
                 - OutOfServiceTaint
                 type: string

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -52,14 +52,16 @@ spec:
                       remediationStrategy:
                         default: Automatic
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes. Currently, it could be either "ResourceDeletion"
-                          or "OutOfServiceTaint". The first will iterate over all
-                          pods and VolumeAttachment related to the unhealthy node
-                          and delete them. The latter will add the out-of-service
-                          taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-                          that enables automatic deletion of pv-attached pods on failed
-                          nodes, "OutOfServiceTaint" is only supported on clusters
-                          with k8s version 1.26+ or OCP/OKD version 4.13+.
+                          for unhealthy nodes. Currently, it could be either "Automatic",
+                          "OutOfServiceTaint" or "ResourceDeletion". ResourceDeletion
+                          will iterate over all pods and VolumeAttachment related
+                          to the unhealthy node and delete them. OutOfServiceTaint
+                          will add the out-of-service taint which is a new well-known
+                          taint "node.kubernetes.io/out-of-service" that enables automatic
+                          deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
+                          is only supported on clusters with k8s version 1.26+ or
+                          OCP/OKD version 4.13+. Automatic will choose the most appropriate
+                          strategy during runtime.
                         enum:
                         - Automatic
                         - ResourceDeletion

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -58,10 +58,10 @@ spec:
                           to the unhealthy node and delete them. OutOfServiceTaint
                           will add the out-of-service taint which is a new well-known
                           taint "node.kubernetes.io/out-of-service" that enables automatic
-                          deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
-                          is only supported on clusters with k8s version 1.26+ or
-                          OCP/OKD version 4.13+. Automatic will choose the most appropriate
-                          strategy during runtime.
+                          deletion of pv-attached pods on failed nodes, "out-of-service"
+                          taint is only supported on clusters with k8s version 1.26+
+                          or OCP/OKD version 4.13+. Automatic will choose the most
+                          appropriate strategy during runtime.
                         enum:
                         - Automatic
                         - ResourceDeletion

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -50,7 +50,7 @@ spec:
                       of SelfNodeRemediation
                     properties:
                       remediationStrategy:
-                        default: ResourceDeletion
+                        default: Automatic
                         description: RemediationStrategy is the remediation method
                           for unhealthy nodes. Currently, it could be either "ResourceDeletion"
                           or "OutOfServiceTaint". The first will iterate over all
@@ -61,6 +61,7 @@ spec:
                           nodes, "OutOfServiceTaint" is only supported on clusters
                           with k8s version 1.26+ or OCP/OKD version 4.13+.
                         enum:
+                        - Automatic
                         - ResourceDeletion
                         - OutOfServiceTaint
                         type: string

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -41,13 +41,15 @@ spec:
               remediationStrategy:
                 default: Automatic
                 description: RemediationStrategy is the remediation method for unhealthy
-                  nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
-                  The first will iterate over all pods and VolumeAttachment related
-                  to the unhealthy node and delete them. The latter will add the out-of-service
-                  taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-                  that enables automatic deletion of pv-attached pods on failed nodes,
-                  "OutOfServiceTaint" is only supported on clusters with k8s version
-                  1.26+ or OCP/OKD version 4.13+.
+                  nodes. Currently, it could be either "Automatic", "OutOfServiceTaint"
+                  or "ResourceDeletion". ResourceDeletion will iterate over all pods
+                  and VolumeAttachment related to the unhealthy node and delete them.
+                  OutOfServiceTaint will add the out-of-service taint which is a new
+                  well-known taint "node.kubernetes.io/out-of-service" that enables
+                  automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
+                  is only supported on clusters with k8s version 1.26+ or OCP/OKD
+                  version 4.13+. Automatic will choose the most appropriate strategy
+                  during runtime.
                 enum:
                 - Automatic
                 - ResourceDeletion

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -46,8 +46,8 @@ spec:
                   and VolumeAttachment related to the unhealthy node and delete them.
                   OutOfServiceTaint will add the out-of-service taint which is a new
                   well-known taint "node.kubernetes.io/out-of-service" that enables
-                  automatic deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
-                  is only supported on clusters with k8s version 1.26+ or OCP/OKD
+                  automatic deletion of pv-attached pods on failed nodes, "out-of-service"
+                  taint is only supported on clusters with k8s version 1.26+ or OCP/OKD
                   version 4.13+. Automatic will choose the most appropriate strategy
                   during runtime.
                 enum:

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediations.yaml
@@ -39,7 +39,7 @@ spec:
             description: SelfNodeRemediationSpec defines the desired state of SelfNodeRemediation
             properties:
               remediationStrategy:
-                default: ResourceDeletion
+                default: Automatic
                 description: RemediationStrategy is the remediation method for unhealthy
                   nodes. Currently, it could be either "ResourceDeletion" or "OutOfServiceTaint".
                   The first will iterate over all pods and VolumeAttachment related
@@ -49,6 +49,7 @@ spec:
                   "OutOfServiceTaint" is only supported on clusters with k8s version
                   1.26+ or OCP/OKD version 4.13+.
                 enum:
+                - Automatic
                 - ResourceDeletion
                 - OutOfServiceTaint
                 type: string

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -56,10 +56,10 @@ spec:
                           to the unhealthy node and delete them. OutOfServiceTaint
                           will add the out-of-service taint which is a new well-known
                           taint "node.kubernetes.io/out-of-service" that enables automatic
-                          deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
-                          is only supported on clusters with k8s version 1.26+ or
-                          OCP/OKD version 4.13+. Automatic will choose the most appropriate
-                          strategy during runtime.
+                          deletion of pv-attached pods on failed nodes, "out-of-service"
+                          taint is only supported on clusters with k8s version 1.26+
+                          or OCP/OKD version 4.13+. Automatic will choose the most
+                          appropriate strategy during runtime.
                         enum:
                         - Automatic
                         - ResourceDeletion

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -50,14 +50,16 @@ spec:
                       remediationStrategy:
                         default: Automatic
                         description: RemediationStrategy is the remediation method
-                          for unhealthy nodes. Currently, it could be either "ResourceDeletion"
-                          or "OutOfServiceTaint". The first will iterate over all
-                          pods and VolumeAttachment related to the unhealthy node
-                          and delete them. The latter will add the out-of-service
-                          taint which is a new well-known taint "node.kubernetes.io/out-of-service"
-                          that enables automatic deletion of pv-attached pods on failed
-                          nodes, "OutOfServiceTaint" is only supported on clusters
-                          with k8s version 1.26+ or OCP/OKD version 4.13+.
+                          for unhealthy nodes. Currently, it could be either "Automatic",
+                          "OutOfServiceTaint" or "ResourceDeletion". ResourceDeletion
+                          will iterate over all pods and VolumeAttachment related
+                          to the unhealthy node and delete them. OutOfServiceTaint
+                          will add the out-of-service taint which is a new well-known
+                          taint "node.kubernetes.io/out-of-service" that enables automatic
+                          deletion of pv-attached pods on failed nodes, "OutOfServiceTaint"
+                          is only supported on clusters with k8s version 1.26+ or
+                          OCP/OKD version 4.13+. Automatic will choose the most appropriate
+                          strategy during runtime.
                         enum:
                         - Automatic
                         - ResourceDeletion

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationtemplates.yaml
@@ -48,7 +48,7 @@ spec:
                       of SelfNodeRemediation
                     properties:
                       remediationStrategy:
-                        default: ResourceDeletion
+                        default: Automatic
                         description: RemediationStrategy is the remediation method
                           for unhealthy nodes. Currently, it could be either "ResourceDeletion"
                           or "OutOfServiceTaint". The first will iterate over all
@@ -59,6 +59,7 @@ spec:
                           nodes, "OutOfServiceTaint" is only supported on clusters
                           with k8s version 1.26+ or OCP/OKD version 4.13+.
                         enum:
+                        - Automatic
                         - ResourceDeletion
                         - OutOfServiceTaint
                         type: string

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -845,8 +845,8 @@ func (r *SelfNodeRemediationReconciler) addOutOfServiceTaint(node *v1.Node) erro
 		r.logger.Error(err, "Failed to add out-of-service taint on node", "node name", node.Name)
 		return err
 	}
-	r.Recorder.Event(node, eventTypeNormal, eventReasonAddOutOfService, "Remediation process - add OutOfService taint to unhealthy node")
-	r.logger.Info("outofservice taint added", "new taints", node.Spec.Taints)
+	r.Recorder.Event(node, eventTypeNormal, eventReasonAddOutOfService, "Remediation process - add out-of-service taint to unhealthy node")
+	r.logger.Info("out-of-service taint added", "new taints", node.Spec.Taints)
 	return nil
 }
 
@@ -867,8 +867,8 @@ func (r *SelfNodeRemediationReconciler) removeOutOfServiceTaint(node *v1.Node) e
 		r.logger.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", OutOfServiceTaint.Key, "taint effect", OutOfServiceTaint.Effect)
 		return err
 	}
-	r.Recorder.Event(node, eventTypeNormal, eventReasonRemoveOutOfService, "Remediation process - remove OutOfService taint from node")
-	r.logger.Info("outofservice taint removed", "new taints", node.Spec.Taints)
+	r.Recorder.Event(node, eventTypeNormal, eventReasonRemoveOutOfService, "Remediation process - remove out-of-service taint from node")
+	r.logger.Info("out-of-service taint removed", "new taints", node.Spec.Taints)
 	return nil
 }
 

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -56,11 +56,13 @@ const (
 	eventReasonAddFinalizer              = "AddFinalizer"
 	eventReasonMarkUnschedulable         = "MarkUnschedulable"
 	eventReasonAddNoExecute              = "AddNoExecute"
+	eventReasonAddOutOfService           = "AddOutOfService"
 	eventReasonUpdateTimeAssumedRebooted = "UpdateTimeAssumedRebooted"
 	eventReasonDeleteResources           = "DeleteResources"
 	eventReasonMarkSchedulable           = "MarkNodeSchedulable"
 	eventReasonRemoveFinalizer           = "RemoveFinalizer"
 	eventReasonRemoveNoExecute           = "RemoveNoExecuteTaint"
+	eventReasonRemoveOutOfService        = "RemoveOutOfService"
 	eventReasonNodeReboot                = "NodeReboot"
 
 	eventTypeNormal = "Normal"
@@ -843,6 +845,7 @@ func (r *SelfNodeRemediationReconciler) addOutOfServiceTaint(node *v1.Node) erro
 		r.logger.Error(err, "Failed to add out-of-service taint on node", "node name", node.Name)
 		return err
 	}
+	r.Recorder.Event(node, eventTypeNormal, eventReasonAddOutOfService, "Remediation process - add OutOfService taint to unhealthy node")
 	r.logger.Info("outofservice taint added", "new taints", node.Spec.Taints)
 	return nil
 }
@@ -864,6 +867,7 @@ func (r *SelfNodeRemediationReconciler) removeOutOfServiceTaint(node *v1.Node) e
 		r.logger.Error(err, "Failed to remove taint from node,", "node name", node.Name, "taint key", OutOfServiceTaint.Key, "taint effect", OutOfServiceTaint.Effect)
 		return err
 	}
+	r.Recorder.Event(node, eventTypeNormal, eventReasonRemoveOutOfService, "Remediation process - remove OutOfService taint from node")
 	r.logger.Info("outofservice taint removed", "new taints", node.Spec.Taints)
 	return nil
 }

--- a/controllers/tests/controller/selfnoderemediation_controller_test.go
+++ b/controllers/tests/controller/selfnoderemediation_controller_test.go
@@ -294,7 +294,7 @@ var _ = Describe("SNR Controller", func() {
 
 				verifyOutOfServiceTaintExist()
 
-				verifyEvent("Normal", "AddOutOfService", "Remediation process - add OutOfService taint to unhealthy node")
+				verifyEvent("Normal", "AddOutOfService", "Remediation process - add out-of-service taint to unhealthy node")
 
 				// simulate the out-of-service taint by Pod GC Controller
 				deleteTerminatingPod()
@@ -303,7 +303,7 @@ var _ = Describe("SNR Controller", func() {
 
 				verifyOutOfServiceTaintRemoved()
 
-				verifyEvent("Normal", "RemoveOutOfService", "Remediation process - remove OutOfService taint from node")
+				verifyEvent("Normal", "RemoveOutOfService", "Remediation process - remove out-of-service taint from node")
 
 				verifyTypeConditions(snr.Name, metav1.ConditionFalse, metav1.ConditionTrue, "RemediationFinishedSuccessfully")
 

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
-		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
+		setupLog.Error(err, "unable to verify out-of-service taint support. out-of-service taint isn't supported")
 	}
 
 	if isManager {

--- a/main.go
+++ b/main.go
@@ -121,6 +121,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
+		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
+	}
+
 	if isManager {
 		initSelfNodeRemediationManager(mgr, enableHTTP2)
 	} else {
@@ -149,10 +153,6 @@ func initSelfNodeRemediationManager(mgr manager.Manager, enableHTTP2 bool) {
 	setupLog.Info("Starting as a manager that installs the daemonset")
 
 	configureWebhookServer(mgr, enableHTTP2)
-
-	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
-		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
-	}
 
 	if err := (&selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "SelfNodeRemediationConfig")
@@ -274,10 +274,6 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 			os.Exit(1)
 		}
 		wasWatchdogInitiated = true
-	}
-
-	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
-		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
 	}
 
 	if err = utils.UpdateNodeWithIsRebootCapableAnnotation(wasWatchdogInitiated, myNodeName, mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func initSelfNodeRemediationManager(mgr manager.Manager, enableHTTP2 bool) {
 
 	configureWebhookServer(mgr, enableHTTP2)
 
-	if err := utils.InitOutOfServiceTaintSupportedFlag(mgr.GetConfig()); err != nil {
+	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
 		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
 	}
 
@@ -274,6 +274,10 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 			os.Exit(1)
 		}
 		wasWatchdogInitiated = true
+	}
+
+	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
+		setupLog.Error(err, "unable to verify out of service taint support. out of service taint isn't supported")
 	}
 
 	if err = utils.UpdateNodeWithIsRebootCapableAnnotation(wasWatchdogInitiated, myNodeName, mgr); err != nil {

--- a/pkg/utils/taints_test.go
+++ b/pkg/utils/taints_test.go
@@ -31,8 +31,8 @@ func Test_setOutOfTaintSupportedFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			IsOutOfServiceTaintSupported = false
-			if err := setOutOfTaintSupportedFlag(tt.args.version); (err != nil) != tt.wantErr || IsOutOfServiceTaintSupported != tt.isOutOfTaintFlagEnabled {
-				t.Errorf("setOutOfTaintSupportedFlag() error = %v, wantErr %v, expected out of taint flag %v", err, tt.wantErr, tt.isOutOfTaintFlagEnabled)
+			if err := setOutOfTaintFlags(tt.args.version); (err != nil) != tt.wantErr || IsOutOfServiceTaintSupported != tt.isOutOfTaintFlagEnabled {
+				t.Errorf("setOutOfTaintFlags() error = %v, wantErr %v, expected out of taint flag %v", err, tt.wantErr, tt.isOutOfTaintFlagEnabled)
 			}
 		})
 	}


### PR DESCRIPTION
[ECOPROJECT-1752](https://issues.redhat.com//browse/ECOPROJECT-1752)
At the moment the default remediation Strategy is `ResourceDeletion`, for newer clusters (ocp 4.14+) it's recommended to use the newer implementation of the Out of Service taint which is used in the `OutOfService` strategy.
In order to achieve this we plan to create a new default strategy `Automatic` which will decide the remediation strategy SNR will use at runtime depending on the cluster.
This change also meant for a better integration of other future strategies