### PR TITLE
adding label on default template

### DIFF
--- a/api/v1alpha1/selfnoderemediation_types.go
+++ b/api/v1alpha1/selfnoderemediation_types.go
@@ -23,6 +23,7 @@ import (
 const (
 	ResourceDeletionRemediationStrategy  = RemediationStrategyType("ResourceDeletion")
 	OutOfServiceTaintRemediationStrategy = RemediationStrategyType("OutOfServiceTaint")
+	DefaultRemediationStrategy           = ResourceDeletionRemediationStrategy
 	// ProcessingConditionType is the condition type used to signal NHC the remediation status
 	ProcessingConditionType = "Processing"
 	// SucceededConditionType is the condition type used to signal NHC whether the remediation was successful or not

--- a/api/v1alpha1/selfnoderemediationtemplate_types.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_types.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/medik8s/common/pkg/labels"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	resourceDeletionTemplateName = "self-node-remediation-resource-deletion-template"
+	defaultTemplateName = "self-node-remediation-resource-deletion-template"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -71,15 +73,18 @@ func init() {
 }
 
 func NewRemediationTemplates() []*SelfNodeRemediationTemplate {
+	templateLabels := make(map[string]string)
+	templateLabels[labels.DefaultTemplate] = "true"
 	return []*SelfNodeRemediationTemplate{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: resourceDeletionTemplateName,
+				Name:   defaultTemplateName,
+				Labels: templateLabels,
 			},
 			Spec: SelfNodeRemediationTemplateSpec{
 				Template: SelfNodeRemediationTemplateResource{
 					Spec: SelfNodeRemediationSpec{
-						RemediationStrategy: ResourceDeletionRemediationStrategy,
+						RemediationStrategy: DefaultRemediationStrategy,
 					},
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/go-ping/ping v1.1.0
-	github.com/medik8s/common v1.9.0
+	github.com/medik8s/common v1.10.0
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.9.0 h1:nMMffmj+e0l0xRB0RfpsbdDpW9upXU2MFeGGADJlwyE=
-github.com/medik8s/common v1.9.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
+github.com/medik8s/common v1.10.0 h1:ghvW/Kiv9xdkJbFhzeh38dSmx0ltoZNT7cHrCh3WpX4=
+github.com/medik8s/common v1.10.0/go.mod h1:ZT/3hfMXJLmZEcqmxRWB5LGC8Wl+qKGGQ4zM8hOE7PY=
 github.com/mitchellh/copystructure v1.1.2 h1:Th2TIvG1+6ma3e/0/bopBKohOTY7s4dA8V2q4EUcBJ0=
 github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=

--- a/vendor/github.com/medik8s/common/pkg/labels/labels.go
+++ b/vendor/github.com/medik8s/common/pkg/labels/labels.go
@@ -7,4 +7,6 @@ const (
 	MasterRole = "node-role.kubernetes.io/master"
 	// ControlPlaneRole is the new role label of control plane nodes
 	ControlPlaneRole = "node-role.kubernetes.io/control-plane"
+	// DefaultTemplate label indicates to third party tools (e.g. UI) the default remediation template in case several exists.
+	DefaultTemplate = "remediation.medik8s.io/default-template"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.9.0
+# github.com/medik8s/common v1.10.0
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/nodes


### PR DESCRIPTION
[ECOPROJECT-1759](https://issues.redhat.com//browse/ECOPROJECT-1759)

ATM The UI is looking for SNR Template with the default remediation strategy completely hard coded (i.e hard coded for ResourceDeletion).
In order to make the UI more robust and prevent unnecessary changes in the UI when the default Strategy is changed, we'd put a label on the Template with the default strategy instead.