### PR TITLE
adding node selector to snr daemonset

### DIFF
--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -26,6 +26,15 @@ spec:
             type: Directory
       serviceAccountName: self-node-remediation-controller-manager
       priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: remediation.medik8s.io/exclude-from-remediation
+                  operator: NotIn
+                  values:
+                  - "true"
       containers:
       - args:
         - --is-manager=false


### PR DESCRIPTION
[ECOPROJECT-1747](https://issues.redhat.com//browse/ECOPROJECT-1747)
Adding a node selector which will allow preventing SNR daemonset to run on a specific node.
This functionality is required for use cases where we would like to disable SNR (for example Node maintenance).