### PR TITLE
SNR wrongly identify the remediation created by MHC (instead of NHC)

### DIFF
--- a/controllers/tests/controller/suite_test.go
+++ b/controllers/tests/controller/suite_test.go
@@ -26,8 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
-
-	//+kubebuilder:scaffold:imports
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -47,6 +45,7 @@ import (
 	"github.com/medik8s/self-node-remediation/pkg/peers"
 	"github.com/medik8s/self-node-remediation/pkg/reboot"
 	"github.com/medik8s/self-node-remediation/pkg/watchdog"
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/pkg/peerhealth/server.go
+++ b/pkg/peerhealth/server.go
@@ -124,7 +124,7 @@ func (s Server) IsHealthy(ctx context.Context, request *HealthRequest) (*HealthR
 	s.log.Info("checking health for", "node", nodeName)
 
 	namespace := s.snr.GetLastSeenSnrNamespace()
-	isMachine := s.snr.WasLastSeenSnrMachine()
+	isMachine := s.snr.IsSnrMatchMachineName()
 
 	// when namespace is empty, there wasn't a SNR yet, which also means that the node must be healthy
 	if namespace == "" {


### PR DESCRIPTION
[ECOPROJECT-1772](https://issues.redhat.com//browse/ECOPROJECT-1772)
SNR Misinterprets CR Association when template configures in openshift-machine-api ns, leading to Incorrect peer check in case of API issues.

When a SNR template is configured in the openshift-machine-api for use with NHC, an issue arises. SNR incorrectly assumes that CRs  are generated by MHC and wrongly identifies the CR name as the Machine name. 
However, the CR name corresponds to the Node name.This misinterpretation becomes problematic during peer checks,in case of API issues. 
SNR searches for CRs using the incorrect Machine name instead of the Node name. 

Consequently, it consistently returns a "you're healthy" status, as it fails to locate the expected CR associated with the Node name. 