### PR TITLE
add 'replaces' to csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ OPERATOR_NAME ?= self-node-remediation
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 DEFAULT_VERSION := 0.0.1
 VERSION ?= $(DEFAULT_VERSION)
+PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
 
 CHANNELS = stable
@@ -307,10 +308,10 @@ bundle-update: verify-previous-version ## Update CSV fields and validate the bun
 
 .PHONY: verify-previous-version
 verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
-	@if [ -z "$$PREVIOUS_VERSION" ]; then \
-		echo "Error: PREVIOUS_VERSION is not set"; \
-		exit 1; \
-	fi
+	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
+  			echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
+    		exit 1; \
+    fi
 
 .PHONY: bundle-validate
 bundle-validate: operator-sdk ## Validate the bundle directory with additional validators (suite=operatorframework), such as Kubernetes deprecated APIs (https://kubernetes.io/docs/reference/using-api/deprecation-guide/) based on bundle.CSV.Spec.MinKubeVersion

--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ bundle-community: bundle ##Add Community Edition suffix to operator name
 	sed -r -i "s|displayName: Self Node Remediation Operator.*|displayName: Self Node Remediation Operator - Community Edition|;" ${BUNDLE_CSV}
 
 .PHONY: bundle-update
-bundle-update: verify-previous-version ## Update containerImage, createdAt, skipRange, and icon fields in the bundle's CSV, then validate the bundle directory
+bundle-update: verify-previous-version ## Update CSV fields and validate the bundle directory
 	# update container image in the metadata
 	sed -r -i "s|containerImage: .*|containerImage: ${IMG}|;" ${BUNDLE_CSV}
 	# set creation date

--- a/Makefile
+++ b/Makefile
@@ -291,22 +291,32 @@ bundle-community-k8s: bundle-community ## Generate bundle manifests and metadata
 bundle-community: bundle ##Add Community Edition suffix to operator name
 	sed -r -i "s|displayName: Self Node Remediation Operator.*|displayName: Self Node Remediation Operator - Community Edition|;" ${BUNDLE_CSV}
 
-# Split the VERSION into major, minor, and patch parts
-MAJOR := $(word 1, $(subst ., ,$(VERSION)))
-MINOR := $(word 2, $(subst ., ,$(VERSION)))
-PATCH := $(word 3, $(subst ., ,$(VERSION)))
 
-# Determine which part to decrease
-ifeq ($(PATCH),0)
-    # If PATCH is 0, decrease MINOR
-    MINOR := $(shell echo $$(($(MINOR) - 1)))
+# Create the DEC_VERSION variable
+DEC_VERSION := 0.0.0
+
+# Check if PREV_VERSION is defined
+ifdef PREV_VERSION
+    # If PREV_VERSION is defined, use its value for DEC_VERSION
+    DEC_VERSION := $(PREV_VERSION)
 else
-    # If PATCH is greater than 0, decrease PATCH
-   PATCH := $(shell echo $$(($(PATCH) - 1)))
-endif
+	# Split the VERSION into major, minor, and patch parts
+	MAJOR := $(word 1, $(subst ., ,$(VERSION)))
+	MINOR := $(word 2, $(subst ., ,$(VERSION)))
+	PATCH := $(word 3, $(subst ., ,$(VERSION)))
 
-# Recreate the DEC_VERSION variable
-DEC_VERSION := $(MAJOR).$(MINOR).$(PATCH)
+	# Determine which part to decrease
+	ifeq ($(PATCH),0)
+		# If PATCH is 0, decrease MINOR
+		MINOR := $(shell echo $$(($(MINOR) - 1)))
+	else
+		# If PATCH is greater than 0, decrease PATCH
+	   PATCH := $(shell echo $$(($(PATCH) - 1)))
+	endif
+
+	# Recreate the DEC_VERSION variable
+	DEC_VERSION := $(MAJOR).$(MINOR).$(PATCH)
+endif
 
 .PHONY: bundle-update
 bundle-update: ## Update containerImage, createdAt, skipRange, and icon fields in the bundle's CSV, then validate the bundle directory

--- a/Makefile
+++ b/Makefile
@@ -296,12 +296,17 @@ MAJOR := $(word 1, $(subst ., ,$(VERSION)))
 MINOR := $(word 2, $(subst ., ,$(VERSION)))
 PATCH := $(word 3, $(subst ., ,$(VERSION)))
 
-# Subtract 1 from the MINOR part
-NEW_MINOR := $(shell echo $$(($(MINOR) - 1)))
-NEW_MINOR := $(if $(filter $(NEW_MINOR),-1),0,$(NEW_MINOR))
+# Determine which part to decrease
+ifeq ($(PATCH),0)
+    # If PATCH is 0, decrease MINOR
+    MINOR := $(shell echo $$(($(MINOR) - 1)))
+else
+    # If PATCH is greater than 0, decrease PATCH
+   PATCH := $(shell echo $$(($(PATCH) - 1)))
+endif
 
 # Recreate the DEC_VERSION variable
-DEC_VERSION := $(MAJOR).$(NEW_MINOR).$(PATCH)
+DEC_VERSION := $(MAJOR).$(MINOR).$(PATCH)
 
 .PHONY: bundle-update
 bundle-update: ## Update containerImage, createdAt, skipRange, and icon fields in the bundle's CSV, then validate the bundle directory

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -439,6 +439,7 @@ spec:
   provider:
     name: Medik8s
     url: https://www.medik8s.io/
+  replaces: self-node-remediation.v0.0.0
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -439,7 +439,7 @@ spec:
   provider:
     name: Medik8s
     url: https://www.medik8s.io/
-  replaces: self-node-remediation.v0.0.0
+  replaces: self-node-remediation.v0.0.1
   version: 0.0.1
   webhookdefinitions:
   - admissionReviewVersions:

--- a/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
@@ -124,4 +124,5 @@ spec:
   provider:
     name: Medik8s
     url: https://www.medik8s.io/
+  replaces: self-node-remediation.v0.0.0
   version: 0.0.0

--- a/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/self-node-remediation.clusterserviceversion.yaml
@@ -124,5 +124,5 @@ spec:
   provider:
     name: Medik8s
     url: https://www.medik8s.io/
-  replaces: self-node-remediation.v0.0.0
+  replaces: self-node-remediation.v0.0.1
   version: 0.0.0


### PR DESCRIPTION
[ECOPROJECT-1767](https://issues.redhat.com//browse/ECOPROJECT-1767)

We need to update our CSVs with the following required metadata:

1. "replace" field:
while we use "skipRange" for defining from which versions we can update to the version of the CSV, we also need to add the "replace" field. It should point to the last released version, and ensures that the old version isn't deleted from the index, so customers can continue to use their tested and approved version.

https://docs.engineering.redhat.com/display/CFC/Best_Practices#Best_Practices-SkipRange

