### PR TITLE
Clean operator start errors due to update conflict

### DIFF
--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -160,7 +160,9 @@ func (r *SelfNodeRemediationConfigReconciler) syncConfigDaemonSet(ctx context.Co
 		}
 		err = r.syncK8sResource(ctx, snrConfig, obj)
 		if err != nil {
-			logger.Error(err, "Couldn't sync self-node-remediation daemons objects")
+			if !errors.IsConflict(err) {
+				logger.Error(err, "Couldn't sync self-node-remediation daemons objects")
+			}
 			return err
 		}
 	}

--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -160,7 +160,9 @@ func (r *SelfNodeRemediationConfigReconciler) syncConfigDaemonSet(ctx context.Co
 		}
 		err = r.syncK8sResource(ctx, snrConfig, obj)
 		if err != nil {
-			if !errors.IsConflict(err) {
+			if errors.IsConflict(err) {
+				logger.Info("Couldn't sync self-node-remediation daemons objects because ds is updated, retrying...")
+			} else {
 				logger.Error(err, "Couldn't sync self-node-remediation daemons objects")
 			}
 			return err


### PR DESCRIPTION
[ECOPROJECT-1828](https://issues.redhat.com//browse/ECOPROJECT-1828)
Some log errors show on operator start due to a conflict of updating the ds