### PR TITLE
Updating "Automatic" log message

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -913,10 +913,7 @@ func (r *SelfNodeRemediationReconciler) getRuntimeStrategy(snr *v1alpha1.SelfNod
 		remediationStrategy = v1alpha1.OutOfServiceTaintRemediationStrategy
 	}
 
-	//used as an indication not to spam the log
-	if isFinalizerAlreadyAdded := controllerutil.ContainsFinalizer(snr, SNRFinalizer); !isFinalizerAlreadyAdded {
-		r.logger.Info(fmt.Sprintf("Automatically selected %s Remediation strategy", remediationStrategy))
-	}
+	r.logger.Info(fmt.Sprintf("Remediating with %s Remediation strategy (auto-selected)", remediationStrategy))
 
 	return remediationStrategy
 


### PR DESCRIPTION
[ECOPROJECT-1862](https://issues.redhat.com//browse/ECOPROJECT-1862) 
- Considering a use case where the finalizer is placed by the agent and than we loose connectivity after reboot, missing this log message.
- Also fixing a flaky UT in config