### PR TITLE
Last error not recorded

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -220,7 +220,7 @@ func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.
 				return ctrl.Result{}, err
 			}
 			events.NormalEvent(r.Recorder, snr, eventReasonRemediationStopped, "couldn't find node matching remediation")
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, r.updateSnrStatusLastError(snr, err)
 		}
 		r.logger.Error(err, "failed to get node", "node name", snr.Name)
 		return ctrl.Result{}, err


### PR DESCRIPTION
[ECOPROJECT-1864](https://issues.redhat.com//browse/ECOPROJECT-1864)
fixing a regression where SNR doesn't record the last error in case node isn't found.