### PR TITLE
[WIP] increase SafeTimeToAssumeNodeRebootedSeconds 

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -47,7 +47,7 @@ type SelfNodeRemediationConfigSpec struct {
 	// In an effort to prevent this, the operator ignores values lower than a minimum calculated from the
 	// ApiCheckInterval, ApiServerTimeout, MaxApiErrorThreshold, PeerDialTimeout, and PeerRequestTimeout fields.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:default=180
+	// +kubebuilder:default=210
 	SafeTimeToAssumeNodeRebootedSeconds int `json:"safeTimeToAssumeNodeRebootedSeconds,omitempty"`
 
 	// Valid time units are "ms", "s", "m", "h".

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -144,7 +144,7 @@ spec:
                 pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               safeTimeToAssumeNodeRebootedSeconds:
-                default: 180
+                default: 210
                 description: SafeTimeToAssumeNodeRebootedSeconds is the time after
                   which the healthy self node remediation agents will assume the unhealthy
                   node has been rebooted, and it is safe to recover affected workloads.

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -142,7 +142,7 @@ spec:
                 pattern: ^(0|([0-9]+(\.[0-9]+)?(ms|s|m|h)))$
                 type: string
               safeTimeToAssumeNodeRebootedSeconds:
-                default: 180
+                default: 210
                 description: SafeTimeToAssumeNodeRebootedSeconds is the time after
                   which the healthy self node remediation agents will assume the unhealthy
                   node has been rebooted, and it is safe to recover affected workloads.

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -232,7 +232,7 @@ var _ = Describe("SNR Config Test", func() {
 			}, 5*time.Second, 250*time.Millisecond).Should(BeNil())
 
 			Expect(createdConfig.Spec.WatchdogFilePath).To(Equal("/dev/watchdog"))
-			Expect(createdConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds).To(Equal(180))
+			Expect(createdConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds).To(Equal(210))
 			Expect(createdConfig.Spec.MaxApiErrorThreshold).To(Equal(3))
 
 			Expect(createdConfig.Spec.PeerApiServerTimeout.Seconds()).To(BeEquivalentTo(5))


### PR DESCRIPTION
increase SafeTimeToAssumeNodeRebootedSeconds as in some clusters it's value is lower than minimum calculated value