### PR TITLE
Events refactoring

### DIFF
--- a/controllers/tests/controller/selfnoderemediation_controller_test.go
+++ b/controllers/tests/controller/selfnoderemediation_controller_test.go
@@ -167,7 +167,7 @@ var _ = Describe("SNR Controller", func() {
 			It("Remediation flow", func() {
 				node := verifyNodeIsUnschedulable()
 
-				verifyEvent("Normal", "RemediationStarted", "Remediation started")
+				verifyEvent("Normal", "RemediationStarted", "Remediation started by SNR manager")
 
 				verifyEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
 
@@ -252,8 +252,7 @@ var _ = Describe("SNR Controller", func() {
 
 				It("remediation should stop and update conditions", func() {
 					verifyTypeConditions(snr.Name, metav1.ConditionFalse, metav1.ConditionFalse, "RemediationSkippedNodeNotFound")
-
-					verifyEvent("Normal", "RemediationStopped", "couldn't find node matching remediation")
+					verifyEvent("Warning", "RemediationCannotStart", "Could not get remediation target Node")
 				})
 			})
 
@@ -396,7 +395,7 @@ var _ = Describe("SNR Controller", func() {
 							time.Sleep(time.Second)
 							verifyNoEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
 							verifyTypeConditions(snr.Name, metav1.ConditionFalse, metav1.ConditionFalse, "RemediationSkippedNodeNotFound")
-							verifyEvent("Normal", "RemediationStopped", "couldn't find node matching remediation")
+							verifyEvent("Warning", "RemediationCannotStart", "Could not get remediation target Node")
 						})
 					})
 					When("NHC isn set as owner in the remediation", func() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/go-ping/ping v1.1.0
-	github.com/medik8s/common v1.12.0
+	github.com/medik8s/common v1.15.1
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.12.0 h1:UJ5VS4rbo/K0snfuqRiYam1NhXTwo4Q7fTng34YSlmA=
-github.com/medik8s/common v1.12.0/go.mod h1:Q6YR2rgyiLl6ob4Mx2uDBmybAB3d94fImwoHPbeiE54=
+github.com/medik8s/common v1.15.1 h1:qo2FBZGSegf5q35AZlWzrmgwW1GfUPNmmWaPhb/Uurc=
+github.com/medik8s/common v1.15.1/go.mod h1:A9jYldC6PZcAuBowNNm712FqWdASB2ey5Vjp8MYN/PY=
 github.com/mitchellh/copystructure v1.1.2 h1:Th2TIvG1+6ma3e/0/bopBKohOTY7s4dA8V2q4EUcBJ0=
 github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=

--- a/vendor/github.com/medik8s/common/pkg/events/events.go
+++ b/vendor/github.com/medik8s/common/pkg/events/events.go
@@ -35,17 +35,22 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // Special case events
 
-// RemediationStarted will record a Normal event with reason RemediationStarted and message Remediation started.
+// RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
 }
 
-// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped.
+// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
 }
 
-// RemediationFinished will record a Normal event with reason RemediationFinished and message Remediation finished.
+// RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
 	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+}
+
+// GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
+func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
+	WarningEvent(recorder, object, "RemediationCannotStart", "Could not get remediation target Node")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.12.0
+# github.com/medik8s/common v1.15.1
 ## explicit; go 1.20
 github.com/medik8s/common/pkg/events
 github.com/medik8s/common/pkg/labels


### PR DESCRIPTION
[ECOPROJECT-1836](https://issues.redhat.com//browse/ECOPROJECT-1836)
- not omitting remediation started event for not found nodes
- using node not found event from common
- adding indication of whether the message was omitted by the agent or manager