### PR TITLE
Automate community bundle via GitHub Actions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -8,58 +8,27 @@ on:
 
 jobs:
   push_to_registry:
-    name: Build and push images to quay.io/medik8s
+    name: Build and push unversioned images to quay.io/medik8s
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
           registry: quay.io
 
-      - name: Build and push operator and bundle images, using version 0.0.1, for pushes to main
-        if: ${{ github.ref_type != 'tag' }}
+      - name: Build and push CSV version v0.0.1 with latest images
         run: make container-build-community container-push
 
-      - name: Build and push versioned CSV and images, for tags
-        if: ${{ github.ref_type == 'tag' }}
-        # remove leading 'v' from tag!
-        run: export VERSION=$(echo $GITHUB_REF_NAME | sed 's/v//') && make container-build-community container-push
 
-      - name: Create release with manifests, for tags
-        if: ${{ github.ref_type == 'tag' }}
-        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
-        uses: meeDamian/github-release@2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
-          body: |
-            # Self Node Remediation ${{ github.ref_name }}
-            
-            ## Notable Changes
-            
-            * TODO
-
-            ## Release Artifacts
-            
-            ### Images
-            * Operator: quay.io/medik8s/self-node-remediation-operator:${{ github.ref_name }}
-            * Bundle: quay.io/medik8s/self-node-remediation-operator-bundle:${{ github.ref_name }}
-            * Catalog aka Index: quay.io/medik8s/self-node-remediation-operator-catalog:${{ github.ref_name }}
-            
-            ### Source code and OLM manifests
-            Please find the source code and the OLM manifests in the `Assets` section below.
-          gzip: folders
-          files: >
-            Manifests:bundle/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,106 @@
-name: Release bundles
+name: Release
 on:
   workflow_dispatch:
-    inputs:
-        version:
-          description: "The version to release, without the leading `v`"
-          required: true
-          type: string
-        previous_version:
-          description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
-          required: true
-          type: string
+   inputs:
+     operation:
+       description: "The operation to perform."
+       required: true
+       type: choice
+       default: "build_and_push_images"
+       options:
+         - build_and_push_images
+         - create_okd_release_pr
+         - create_k8s_release_pr
+     version:
+       description: "The version to release, without the leading `v`"
+       required: true
+     previous_version:
+       description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
+       required: true
+     ocp_version:
+       description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
+       required: false
+
+permissions:
+  contents: write
 
 jobs:
-  make_rh_community_bundle:
-    uses: medik8s/.github/.github/workflows/release_rh_community_bundle.yml@main
+  push_to_registry:
+    if: ${{ inputs.operation == 'build_and_push_images' }}
+    name: Build and push versioned images to quay.io/medik8s
+    runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ inputs.version }}
+      PREVIOUS_VERSION: ${{ inputs.previous_version }}
+      OCP_VERSION: ${{ inputs.ocp_version }}
+    steps:
+      - name: Log inputs
+        run: |
+          echo "Building version: ${VERSION},"
+          echo "which replaces version: ${PREVIOUS_VERSION}."
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+
+      - name: Build and push versioned CSV and images
+        run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION make container-build-community container-push
+
+      - name: Create release with manifests, for tags
+        if: ${{ github.ref_type == 'tag' }}
+        # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
+        uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          body: |
+            # Self Node Remediation ${{ github.ref_name }}
+            
+            ## Notable Changes
+            
+            * TODO
+
+            ## Release Artifacts
+            
+            ### Images
+            * Operator: quay.io/medik8s/self-node-remediation-operator:${{ github.ref_name }}
+            * Bundle: quay.io/medik8s/self-node-remediation-operator-bundle:${{ github.ref_name }}
+            * Catalog aka Index: quay.io/medik8s/self-node-remediation-operator-catalog:${{ github.ref_name }}
+            
+            ### Source code and OLM manifests
+            Please find the source code and the OLM manifests in the `Assets` section below.
+          gzip: folders
+          files: >
+            Manifests:bundle/
+
+  create_k8s_release_pr:
+    if: inputs.operation == 'create_k8s_release_pr'
+    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
     secrets: inherit
     with:
       version: ${{ inputs.version }}
       previous_version: ${{ inputs.previous_version }}
+      community: 'K8S'
+      make_targets: "bundle-community-k8s"
+  create_okd_release_pr:
+    if: inputs.operation == 'create_okd_release_pr'
+    uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      previous_version: ${{ inputs.previous_version }}
+      community: 'OKD'
+      make_targets: "bundle-community-rh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,14 +60,14 @@ jobs:
         run: VERSION=$VERSION PREVIOUS_VERSION=$PREVIOUS_VERSION make container-build-community container-push
 
       - name: Create release with manifests, for tags
-        if: ${{ github.ref_type == 'tag' }}
         # https://github.com/marketplace/actions/github-release-create-update-and-upload-assets
         uses: meeDamian/github-release@2.0
         with:
+          tag: v${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           body: |
-            # Self Node Remediation ${{ github.ref_name }}
+            # Self Node Remediation v${{ inputs.version }}
             
             ## Notable Changes
             
@@ -76,9 +76,9 @@ jobs:
             ## Release Artifacts
             
             ### Images
-            * Operator: quay.io/medik8s/self-node-remediation-operator:${{ github.ref_name }}
-            * Bundle: quay.io/medik8s/self-node-remediation-operator-bundle:${{ github.ref_name }}
-            * Catalog aka Index: quay.io/medik8s/self-node-remediation-operator-catalog:${{ github.ref_name }}
+            * Operator: quay.io/medik8s/self-node-remediation-operator:v${{ inputs.version }}
+            * Bundle: quay.io/medik8s/self-node-remediation-operator-bundle:v${{ inputs.version }}
+            * Catalog aka Index: quay.io/medik8s/self-node-remediation-operator-catalog:v${{ inputs.version }}
             
             ### Source code and OLM manifests
             Please find the source code and the OLM manifests in the `Assets` section below.


### PR DESCRIPTION
#### Why we need this PR:
<!-- A clear description of the problem you are trying to solve -->
Currently, the GitHub Action workflow is only able to create a RH/OKD bundle, while SNR is also supported in K8S community.
Moreover, the need of inputs like `previous version` does not allow to keep using the automatic CI for the release.

#### Changes made
Create a manual workflow to provide the necessary inputs to the shared 
GitHub Action to:                                                      
- build and push versioned images to quay registry                     
- create the OKD release branch, ready for the PR                      
- create the K8S release branch, ready for the PR                     


### Which issue(s) this PR fixes

It contributes to solving
[ECOPROJECT-1579](https://issues.redhat.com/browse/ECOPROJECT-1579)

#### Test plan
Tested locally via nektos/act.
