### PR TITLE
Enable kube-rbac-proxy to be able to reach metrics

### DIFF
--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -380,6 +380,18 @@ spec:
                     memory: 110Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --http2-disable
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: quay.io/brancz/kube-rbac-proxy:v0.15.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: false

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -391,7 +391,18 @@ spec:
                 ports:
                 - containerPort: 8443
                   name: https
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               priorityClassName: system-cluster-critical
               securityContext:
                 runAsNonRoot: false

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-# - manager_auth_proxy_patch.yaml
+- manager_auth_proxy_patch.yaml
 # replacement for above for setting probe and metrics ports
 - manager_ports_patch.yaml
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,3 +20,15 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi


### PR DESCRIPTION
#### Why we need this PR
It enables kube-rbac-proxy container so we could reach metrics.

#### Changes made
- Uncomment `manager_auth_proxy_patch.yaml`
- Regenerate bundle manifests


#### Which issue(s) this PR fixes
Fixes #196, as I hope :)

[ECOPROJECT-1949](https://issues.redhat.com//browse/ECOPROJECT-1949)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
