### PR TITLE
Support Multiple Same Kind Remediation

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -28,6 +28,7 @@ resources:
   path: github.com/medik8s/self-node-remediation/api/v1alpha1
   version: v1alpha1
   webhooks:
+    defaulting: true
     validation: true
     webhookVersion: v1
 - api:

--- a/api/v1alpha1/selfnoderemediationtemplate_webhook.go
+++ b/api/v1alpha1/selfnoderemediationtemplate_webhook.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	"fmt"
 
+	commonAnnotations "github.com/medik8s/common/pkg/annotations"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,6 +38,21 @@ func (r *SelfNodeRemediationTemplate) SetupWebhookWithManager(mgr ctrl.Manager) 
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+// +kubebuilder:webhook:path=/mutate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=self-node-remediation.medik8s.io,resources=selfnoderemediationtemplates,verbs=create;update,versions=v1alpha1,name=mselfnoderemediationtemplate.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &SelfNodeRemediationTemplate{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *SelfNodeRemediationTemplate) Default() {
+	webhookTemplateLog.Info("default", "name", r.Name)
+	if r.GetAnnotations() == nil {
+		r.Annotations = make(map[string]string)
+	}
+	if _, isSameKindSupported := r.GetAnnotations()[commonAnnotations.MultipleTemplatesSupportedAnnotation]; !isSameKindSupported {
+		r.Annotations[commonAnnotations.MultipleTemplatesSupportedAnnotation] = "true"
+	}
 }
 
 //+kubebuilder:webhook:path=/validate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=self-node-remediation.medik8s.io,resources=selfnoderemediationtemplates,verbs=create;update,versions=v1alpha1,name=vselfnoderemediationtemplate.kb.io,admissionReviewVersions=v1

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -470,6 +470,26 @@ spec:
     - v1
     containerPort: 443
     deploymentName: self-node-remediation-controller-manager
+    failurePolicy: Fail
+    generateName: mselfnoderemediationtemplate.kb.io
+    rules:
+    - apiGroups:
+      - self-node-remediation.medik8s.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - selfnoderemediationtemplates
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: self-node-remediation-controller-manager
     failurePolicy: Ignore
     generateName: vselfnoderemediation.kb.io
     rules:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,5 +1,31 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-self-node-remediation-medik8s-io-v1alpha1-selfnoderemediationtemplate
+  failurePolicy: Fail
+  name: mselfnoderemediationtemplate.kb.io
+  rules:
+  - apiGroups:
+    - self-node-remediation.medik8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - selfnoderemediationtemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -649,7 +649,7 @@ func (r *SelfNodeRemediationReconciler) getNodeFromSnr(snr *v1alpha1.SelfNodeRem
 	}
 
 	// since we didn't find a Machine owner ref, we assume that SNR remediation contains the node's name either in the
-	// remediation Name or in its annotation
+	// remediation name or in its annotation
 	node := &v1.Node{}
 	key := client.ObjectKey{
 		Name:      getNodeName(snr),
@@ -936,10 +936,9 @@ func IsOwnedByNHC(snr *v1alpha1.SelfNodeRemediation) bool {
 
 // getNodeName checks for the node name in SNR CR's annotation. If it does not exist it assumes the node name equals to SNR CR's name and returns it.
 func getNodeName(snr *v1alpha1.SelfNodeRemediation) string {
-	if ann := snr.GetAnnotations(); ann != nil {
-		if nodeName, isNodeNameAnnotationExist := ann[commonAnnotations.NodeNameAnnotation]; isNodeNameAnnotationExist {
-			return nodeName
-		}
+	nodeName, isNodeNameAnnotationExist := snr.GetAnnotations()[commonAnnotations.NodeNameAnnotation]
+	if isNodeNameAnnotationExist {
+		return nodeName
 	}
 	return snr.GetName()
 }

--- a/controllers/tests/controller/selfnoderemediation_controller_test.go
+++ b/controllers/tests/controller/selfnoderemediation_controller_test.go
@@ -153,7 +153,7 @@ var _ = Describe("SNR Controller", func() {
 		})
 	})
 
-	Context("Unhealthy node with api-server access mod", func() {
+	Context("Unhealthy node with api-server access", func() {
 
 		BeforeEach(func() {
 			isAdditionalSetupNeeded = true
@@ -911,13 +911,4 @@ func isEventOccurred(eventType string, reason string, message string) bool {
 		fakeRecorder.Events <- unMatchedEvent
 	}
 	return isEventMatch
-}
-
-func checkNodeExist(nodeNameSpacedName types.NamespacedName) {
-	node := &v1.Node{}
-	Eventually(func() error {
-		return k8sClient.Client.Get(context.TODO(), nodeNameSpacedName, node)
-	}, 10*time.Second, 250*time.Millisecond).Should(BeNil())
-	Expect(node.Name).To(Equal(nodeNameSpacedName.Name))
-	Expect(node.CreationTimestamp).ToNot(BeZero())
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/go-ping/ping v1.1.0
-	github.com/medik8s/common v1.15.1
+	github.com/medik8s/common v1.17.0
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 // release-4.13

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2 h1:hAHbPm5IJGijwng3PWk09JkG9WeqChjprR5s9bBZ+OM=
 github.com/matttproud/golang_protobuf_extensions v1.0.2/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/medik8s/common v1.15.1 h1:qo2FBZGSegf5q35AZlWzrmgwW1GfUPNmmWaPhb/Uurc=
-github.com/medik8s/common v1.15.1/go.mod h1:A9jYldC6PZcAuBowNNm712FqWdASB2ey5Vjp8MYN/PY=
+github.com/medik8s/common v1.17.0 h1:AmJKx0tzqGZF27Ot0A4ak85q0F0zqUkVyCvYmm67rtY=
+github.com/medik8s/common v1.17.0/go.mod h1:A9jYldC6PZcAuBowNNm712FqWdASB2ey5Vjp8MYN/PY=
 github.com/mitchellh/copystructure v1.1.2 h1:Th2TIvG1+6ma3e/0/bopBKohOTY7s4dA8V2q4EUcBJ0=
 github.com/mitchellh/copystructure v1.1.2/go.mod h1:EBArHfARyrSWO/+Wyr9zwEkc6XMFB9XyNgFNmRkZZU4=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=

--- a/vendor/github.com/medik8s/common/pkg/annotations/annotations.go
+++ b/vendor/github.com/medik8s/common/pkg/annotations/annotations.go
@@ -1,0 +1,13 @@
+package annotations
+
+const (
+	// NhcTimeOut is the annotation set by NHC to signal the operator that it surpassed its timeout and shall stop its remediation
+	NhcTimedOut = "remediation.medik8s.io/nhc-timed-out"
+
+	// MultipleTemplatesSupportedAnnotation is an annotation that indicates whether multiple templates of the same kind are supported by the template's remediator
+	MultipleTemplatesSupportedAnnotation = "remediation.medik8s.io/multiple-templates-support"
+
+	// NodeNameAnnotation is an annotation that contains the node name and is placed on CRs of remediators which supports multiple templates of the same kind.
+	// It's required in order for the remediator to "know" which unhealthy node the CR represents .
+	NodeNameAnnotation = "remediation.medik8s.io/node-name"
+)

--- a/vendor/github.com/medik8s/common/pkg/events/events.go
+++ b/vendor/github.com/medik8s/common/pkg/events/events.go
@@ -9,9 +9,20 @@ import (
 )
 
 // Event message format "medik8s <operator shortname> <message>"
-const customFmt = "[remediation] %s"
+const (
+	customFmt = "[remediation] %s"
 
-// NormalEvent will record an event with type Normal and fixed message.
+	RemediationStartedEventReason                      = "RemediationStarted"
+	RemediationStoppedEventReason                      = "RemediationStopped"
+	RemediationFinishedEventReason                     = "RemediationFinished"
+	RemediationCannotStartEventReason                  = "RemediationCannotStart"
+	remediationStartedEventMessage                     = "Remediation started"
+	remediationStoppedEventMessage                     = "NHC added the timed-out annotation, remediation will be stopped"
+	remediationFinishedEventMessage                    = "Remediation finished"
+	remediationCannotStartTargetNodeFailedEventMessage = "Could not get remediation target Node"
+)
+
+// NormalEvent will record an event with type Normal and custom message.
 func NormalEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
 	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
@@ -22,7 +33,7 @@ func NormalEventf(recorder record.EventRecorder, object runtime.Object, reason, 
 	recorder.Event(object, corev1.EventTypeNormal, reason, fmt.Sprintf(customFmt, message))
 }
 
-// WarningEvent will record an event with type Warning and fixed message.
+// WarningEvent will record an event with type Warning and custom message.
 func WarningEvent(recorder record.EventRecorder, object runtime.Object, reason, message string) {
 	recorder.Event(object, corev1.EventTypeWarning, reason, fmt.Sprintf(customFmt, message))
 }
@@ -35,22 +46,29 @@ func WarningEventf(recorder record.EventRecorder, object runtime.Object, reason,
 
 // Special case events
 
-// RemediationStarted will record a Normal event with reason RemediationStarted and message "Remediation started".
+// RemediationStarted will record a Normal event to signal that the remediation has started.
 func RemediationStarted(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationStarted", "Remediation started")
+	NormalEvent(recorder, object, RemediationStartedEventReason, remediationStartedEventMessage)
 }
 
-// RemediationStoppedByNHC will record a Normal event with reason RemediationStopped and message "NHC added the timed-out annotation, remediation will be stopped".
+// RemediationStoppedByNHC will record a Normal event to signal that the remediation was stopped by the Node Healthcheck operator.
 func RemediationStoppedByNHC(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped")
+	NormalEvent(recorder, object, RemediationStoppedEventReason, remediationStoppedEventMessage)
 }
 
-// RemediationFinished will record a Normal event with reason RemediationFinished and message "Remediation finished".
+// RemediationFinished will record a Normal event to signal that the remediation has finished.
 func RemediationFinished(recorder record.EventRecorder, object runtime.Object) {
-	NormalEvent(recorder, object, "RemediationFinished", "Remediation finished")
+	NormalEvent(recorder, object, RemediationFinishedEventReason, remediationFinishedEventMessage)
 }
 
-// GetTargetNodeFailed will record a Warning event with reason RemediationFailed and message "Could not get remediation target node".
+// RemediationCannotStart will record a Warning event to signal that the remediation cannot start. A custom message can
+// be used to further explain the reason.
+func RemediationCannotStart(recorder record.EventRecorder, object runtime.Object, message string) {
+	WarningEvent(recorder, object, RemediationCannotStartEventReason, message)
+}
+
+// GetTargetNodeFailed will record a Warning event to signal that the remediation cannot start because the target Node
+// could not be found.
 func GetTargetNodeFailed(recorder record.EventRecorder, object runtime.Object) {
-	WarningEvent(recorder, object, "RemediationCannotStart", "Could not get remediation target Node")
+	RemediationCannotStart(recorder, object, remediationCannotStartTargetNodeFailedEventMessage)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,8 +107,9 @@ github.com/mailru/easyjson/jwriter
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/medik8s/common v1.15.1
+# github.com/medik8s/common v1.17.0
 ## explicit; go 1.20
+github.com/medik8s/common/pkg/annotations
 github.com/medik8s/common/pkg/events
 github.com/medik8s/common/pkg/labels
 github.com/medik8s/common/pkg/nodes


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
This PR will enable the user to select several SNR Templates (of the same kind) when using NHC escalating remediation.

This feature is dependent on the changes in NHC as well (which is available starting from NHC 0.8.0).

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- Automatically add the `MultipleTemplatesSupportedAnnotation` that enables this feature via "Defaulting" (Mutating) webhook.
- Support that Node's name might come from `NodeNameAnnotation` instead than from remediation's name (when the feature is enabled).
- Updated Common package to the version shipping the new annotations needed by this feature.
- Test coverage for both configurations (supported and unsupported multiple same kind remediation).


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->
https://issues.redhat.com/browse/ECOPROJECT-1930

#### Test plan

