### PR TITLE
Verify there is no more than one configuration

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -163,7 +163,7 @@ func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 	return SelfNodeRemediationConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ConfigCRName,
-			Annotations: map[string]string{utils.IsDefaultConfigurationAnnotation: "true"},
+			Annotations: map[string]string{utils.IsSingletonConfigurationAnnotation: "true"},
 		},
 		Spec: SelfNodeRemediationConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,

--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -159,7 +161,10 @@ func init() {
 
 func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 	return SelfNodeRemediationConfig{
-		ObjectMeta: metav1.ObjectMeta{Name: ConfigCRName},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        ConfigCRName,
+			Annotations: map[string]string{utils.IsDefaultConfigurationAnnotation: "true"},
+		},
 		Spec: SelfNodeRemediationConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,
 			SafeTimeToAssumeNodeRebootedSeconds: DefaultSafeToAssumeNodeRebootTimeout,

--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -19,8 +19,6 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -162,8 +160,7 @@ func init() {
 func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 	return SelfNodeRemediationConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        ConfigCRName,
-			Annotations: map[string]string{utils.IsSingletonConfigurationAnnotation: "true"},
+			Name: ConfigCRName,
 		},
 		Spec: SelfNodeRemediationConfigSpec{
 			WatchdogFilePath:                    defaultWatchdogPath,

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -26,6 +26,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 // fields names
@@ -74,6 +76,7 @@ func (r *SelfNodeRemediationConfig) ValidateCreate() error {
 	return errors.NewAggregate([]error{
 		r.validateTimes(),
 		r.validateCustomTolerations(),
+		r.validateDefault(),
 	})
 
 }
@@ -171,4 +174,11 @@ func validateToleration(toleration v1.Toleration) error {
 		}
 	}
 	return nil
+}
+
+func (r *SelfNodeRemediationConfig) validateDefault() error {
+	if defaultAnnotationVal, isDefaultAnnotationExist := r.Annotations[utils.IsDefaultConfigurationAnnotation]; isDefaultAnnotationExist && defaultAnnotationVal == "true" {
+		return nil
+	}
+	return fmt.Errorf("only single configuration is allowed")
 }

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -178,7 +178,7 @@ func validateToleration(toleration v1.Toleration) error {
 
 func (r *SelfNodeRemediationConfig) validateSingleton() error {
 	if r.Name != ConfigCRName {
-		return fmt.Errorf("only single SelfNodeRemediationConfig is allowed in the cluster with default name: %s", ConfigCRName)
+		return fmt.Errorf("to enforce only one SelfNodeRemediationConfig in the cluster, a name other than %s is not allowed", ConfigCRName)
 	} else if ns, err := utils.GetDeploymentNamespace(); err != nil {
 		return fmt.Errorf("failed to verify the deployment namespace SelfNodeRemediationConfig can not be created")
 	} else if ns != r.Namespace {

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -177,8 +177,13 @@ func validateToleration(toleration v1.Toleration) error {
 }
 
 func (r *SelfNodeRemediationConfig) validateSingleton() error {
-	if singletonAnnotationVal, isSingletonAnnotationExist := r.Annotations[utils.IsSingletonConfigurationAnnotation]; isSingletonAnnotationExist && singletonAnnotationVal == "true" {
-		return nil
+	if r.Name != ConfigCRName {
+		return fmt.Errorf("only single SelfNodeRemediationConfig is allowed in the cluster with default name: %s", ConfigCRName)
+	} else if ns, err := utils.GetDeploymentNamespace(); err != nil {
+		return fmt.Errorf("failed to verify the deployment namespace SelfNodeRemediationConfig can not be created")
+	} else if ns != r.Namespace {
+		return fmt.Errorf("SelfNodeRemediationConfig is only allowed to be created in the namespace: %s", ns)
 	}
-	return fmt.Errorf("only single SelfNodeRemediationConfig is allowed in the cluster")
+
+	return nil
 }

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -76,7 +76,7 @@ func (r *SelfNodeRemediationConfig) ValidateCreate() error {
 	return errors.NewAggregate([]error{
 		r.validateTimes(),
 		r.validateCustomTolerations(),
-		r.validateDefault(),
+		r.validateSingleton(),
 	})
 
 }
@@ -176,8 +176,8 @@ func validateToleration(toleration v1.Toleration) error {
 	return nil
 }
 
-func (r *SelfNodeRemediationConfig) validateDefault() error {
-	if defaultAnnotationVal, isDefaultAnnotationExist := r.Annotations[utils.IsDefaultConfigurationAnnotation]; isDefaultAnnotationExist && defaultAnnotationVal == "true" {
+func (r *SelfNodeRemediationConfig) validateSingleton() error {
+	if singletonAnnotationVal, isSingletonAnnotationExist := r.Annotations[utils.IsSingletonConfigurationAnnotation]; isSingletonAnnotationExist && singletonAnnotationVal == "true" {
 		return nil
 	}
 	return fmt.Errorf("only single SelfNodeRemediationConfig is allowed in the cluster")

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -180,5 +180,5 @@ func (r *SelfNodeRemediationConfig) validateDefault() error {
 	if defaultAnnotationVal, isDefaultAnnotationExist := r.Annotations[utils.IsDefaultConfigurationAnnotation]; isDefaultAnnotationExist && defaultAnnotationVal == "true" {
 		return nil
 	}
-	return fmt.Errorf("only single configuration is allowed")
+	return fmt.Errorf("only single SelfNodeRemediationConfig is allowed in the cluster")
 }

--- a/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
@@ -61,6 +61,16 @@ var _ = Describe("SelfNodeRemediationConfig Validation", func() {
 		// test create validation on a valid CR
 		testValidCR("create")
 
+		When("Config is missing the default label", func() {
+			It("create should be rejected", func() {
+				snrc := createDefaultSelfNodeRemediationConfigCR()
+				err := snrc.ValidateCreate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("only single SelfNodeRemediationConfig is allowed in the cluster"))
+
+			})
+		})
+
 	})
 
 	Describe("updating SelfNodeRemediationConfig CR", func() {
@@ -187,9 +197,7 @@ func testValidCR(validationType string) {
 			} else {
 				err = snrc.ValidateCreate()
 			}
-			if err != nil {
-				Expect(err).NotTo(HaveOccurred())
-			}
+			Expect(err).NotTo(HaveOccurred())
 
 		})
 	})

--- a/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
@@ -10,8 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
-	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 // default CR fields durations
@@ -186,7 +184,7 @@ func testValidCR(validationType string) {
 	snrc.Spec.ApiCheckInterval = &metav1.Duration{Duration: 10*time.Second + 500*time.Millisecond}
 	snrc.Spec.PeerUpdateInterval = &metav1.Duration{Duration: 10 * time.Second}
 	snrc.Spec.CustomDsTolerations = []v1.Toleration{{Key: "validValue", Effect: v1.TaintEffectNoExecute}, {}, {Operator: v1.TolerationOpEqual, TolerationSeconds: pointer.Int64(-5)}, {Value: "SomeValidValue"}}
-	snrc.Annotations = map[string]string{utils.IsDefaultConfigurationAnnotation: "true"}
+	snrc.Annotations = map[string]string{"is-singleton-configuration.self-node-remediation.medik8s.io": "true"}
 
 	Context("for valid CR", func() {
 		It("should not be rejected", func() {

--- a/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
@@ -10,6 +10,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
+	"github.com/medik8s/self-node-remediation/pkg/utils"
 )
 
 // default CR fields durations
@@ -174,6 +176,7 @@ func testValidCR(validationType string) {
 	snrc.Spec.ApiCheckInterval = &metav1.Duration{Duration: 10*time.Second + 500*time.Millisecond}
 	snrc.Spec.PeerUpdateInterval = &metav1.Duration{Duration: 10 * time.Second}
 	snrc.Spec.CustomDsTolerations = []v1.Toleration{{Key: "validValue", Effect: v1.TaintEffectNoExecute}, {}, {Operator: v1.TolerationOpEqual, TolerationSeconds: pointer.Int64(-5)}, {Value: "SomeValidValue"}}
+	snrc.Annotations = map[string]string{utils.IsDefaultConfigurationAnnotation: "true"}
 
 	Context("for valid CR", func() {
 		It("should not be rejected", func() {
@@ -184,8 +187,9 @@ func testValidCR(validationType string) {
 			} else {
 				err = snrc.ValidateCreate()
 			}
-
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				Expect(err).NotTo(HaveOccurred())
+			}
 
 		})
 	})

--- a/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
@@ -85,7 +85,7 @@ var _ = Describe("SelfNodeRemediationConfig Validation", func() {
 					snrc := createDefaultSelfNodeRemediationConfigCR()
 					err := snrc.ValidateCreate()
 					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("only single SelfNodeRemediationConfig is allowed in the cluster"))
+					Expect(err.Error()).To(ContainSubstring("to enforce only one SelfNodeRemediationConfig in the cluster, a name other than"))
 
 				})
 			})

--- a/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -47,45 +48,80 @@ var testItems2 = []field{
 	{peerUpdateInterval, 1 * time.Millisecond, minDurPeerUpdateInterval},
 }
 
+type validationType int
+
+const (
+	create validationType = iota
+	update
+)
+
+func (v validationType) getName() string {
+	switch v {
+	case create:
+		return "create"
+	case update:
+		return "update"
+	default:
+		return "unknown"
+	}
+}
+
 var _ = Describe("SelfNodeRemediationConfig Validation", func() {
 
 	Describe("creating SelfNodeRemediationConfig CR", func() {
 		// test create validation on CRs with time field that has value shorter than allowed
-		testSingleInvalidField("create")
+		testSingleInvalidField(create)
 
 		// test create validation on CRs with multiple fields that has value shorter than allowed
-		testMultipleInvalidFields("create")
+		testMultipleInvalidFields(create)
 
 		// test create validation on a valid CR
-		testValidCR("create")
+		testValidCR(create)
 
-		When("Config is missing the default label", func() {
-			It("create should be rejected", func() {
-				snrc := createDefaultSelfNodeRemediationConfigCR()
-				err := snrc.ValidateCreate()
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("only single SelfNodeRemediationConfig is allowed in the cluster"))
+		Context("Duplicate config create", func() {
 
+			When("CR name doesn't match default name", func() {
+				It("create should be rejected", func() {
+					snrc := createDefaultSelfNodeRemediationConfigCR()
+					err := snrc.ValidateCreate()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("only single SelfNodeRemediationConfig is allowed in the cluster"))
+
+				})
 			})
+
+			When("CR name namespace does not match deployment namespace", func() {
+				It("create should be rejected", func() {
+					snrc := createDefaultSelfNodeRemediationConfigCR()
+					snrc.Name = ConfigCRName
+					_ = os.Setenv("DEPLOYMENT_NAMESPACE", "mock-deployment-namespace")
+
+					err := snrc.ValidateCreate()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("SelfNodeRemediationConfig is only allowed to be created in the namespace:"))
+
+				})
+			})
+
 		})
 
 	})
 
 	Describe("updating SelfNodeRemediationConfig CR", func() {
 		// test update validation on CRs with time field that has value shorter than allowed
-		testSingleInvalidField("update")
+		testSingleInvalidField(update)
 
 		// test update validation on CRs with multiple fields that has value shorter than allowed
-		testMultipleInvalidFields("update")
+		testMultipleInvalidFields(update)
 
 		// test update validation on a valid CR
-		testValidCR("update")
+		testValidCR(update)
 
 	})
 
 })
 
-func testSingleInvalidField(validationType string) {
+func testSingleInvalidField(validationType validationType) {
 	for _, item := range testItems {
 		item := item
 
@@ -95,7 +131,7 @@ func testSingleInvalidField(validationType string) {
 				snrc := createSelfNodeRemediationConfigCR(item.name, item.durationValue)
 
 				var err error
-				if validationType == "update" {
+				if validationType == update {
 					snrcOld := createDefaultSelfNodeRemediationConfigCR()
 					err = snrc.ValidateUpdate(snrcOld)
 				} else {
@@ -108,13 +144,13 @@ func testSingleInvalidField(validationType string) {
 		})
 	}
 
-	Context(fmt.Sprintf("%s validation of customized toleration", validationType), func() {
+	Context(fmt.Sprintf("%s validation of customized toleration", validationType.getName()), func() {
 		It("should be rejected - invalid operator value", func() {
 			snrc := createDefaultSelfNodeRemediationConfigCR()
 			snrc.Spec.CustomDsTolerations = []v1.Toleration{{Key: "validValue", Operator: "dummyInvalidOperatorValue"}}
 
 			var err error
-			if validationType == "update" {
+			if validationType == update {
 				snrcOld := createDefaultSelfNodeRemediationConfigCR()
 				err = snrc.ValidateUpdate(snrcOld)
 			} else {
@@ -129,7 +165,7 @@ func testSingleInvalidField(validationType string) {
 			snrc.Spec.CustomDsTolerations = []v1.Toleration{{Value: "someValue", Operator: "Exists"}}
 
 			var err error
-			if validationType == "update" {
+			if validationType == update {
 				snrcOld := createDefaultSelfNodeRemediationConfigCR()
 				err = snrc.ValidateUpdate(snrcOld)
 			} else {
@@ -142,7 +178,7 @@ func testSingleInvalidField(validationType string) {
 	})
 }
 
-func testMultipleInvalidFields(validationType string) {
+func testMultipleInvalidFields(validationType validationType) {
 	var errorMsg string
 	snrc := createDefaultSelfNodeRemediationConfigCR()
 
@@ -158,7 +194,7 @@ func testMultipleInvalidFields(validationType string) {
 	Context("for CR multiple invalid fields", func() {
 		It("should be rejected", func() {
 			var err error
-			if validationType == "update" {
+			if validationType == update {
 				snrcOld := createDefaultSelfNodeRemediationConfigCR()
 				err = snrc.ValidateUpdate(snrcOld)
 			} else {
@@ -171,9 +207,9 @@ func testMultipleInvalidFields(validationType string) {
 	})
 }
 
-func testValidCR(validationType string) {
+func testValidCR(validationType validationType) {
 	snrc := &SelfNodeRemediationConfig{}
-	snrc.Name = "test"
+	snrc.Name = "self-node-remediation-config"
 	snrc.Namespace = "default"
 
 	// valid (but not default) values for time fields
@@ -184,12 +220,18 @@ func testValidCR(validationType string) {
 	snrc.Spec.ApiCheckInterval = &metav1.Duration{Duration: 10*time.Second + 500*time.Millisecond}
 	snrc.Spec.PeerUpdateInterval = &metav1.Duration{Duration: 10 * time.Second}
 	snrc.Spec.CustomDsTolerations = []v1.Toleration{{Key: "validValue", Effect: v1.TaintEffectNoExecute}, {}, {Operator: v1.TolerationOpEqual, TolerationSeconds: pointer.Int64(-5)}, {Value: "SomeValidValue"}}
-	snrc.Annotations = map[string]string{"is-singleton-configuration.self-node-remediation.medik8s.io": "true"}
 
 	Context("for valid CR", func() {
+		BeforeEach(func() {
+			//Mock deployment namespace
+			if validationType == create {
+				_ = os.Setenv("DEPLOYMENT_NAMESPACE", snrc.Namespace)
+			}
+		})
+
 		It("should not be rejected", func() {
 			var err error
-			if validationType == "update" {
+			if validationType == update {
 				snrcOld := createDefaultSelfNodeRemediationConfigCR()
 				err = snrc.ValidateUpdate(snrcOld)
 			} else {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -14,8 +14,9 @@ import (
 
 const (
 	// IsRebootCapableAnnotation value is the key name for the node's annotation that will determine if node is reboot capable
-	IsRebootCapableAnnotation     = "is-reboot-capable.self-node-remediation.medik8s.io"
-	IsSoftwareRebootEnabledEnvVar = "IS_SOFTWARE_REBOOT_ENABLED"
+	IsRebootCapableAnnotation        = "is-reboot-capable.self-node-remediation.medik8s.io"
+	IsSoftwareRebootEnabledEnvVar    = "IS_SOFTWARE_REBOOT_ENABLED"
+	IsDefaultConfigurationAnnotation = "is-default-configuration.self-node-remediation.medik8s.io"
 )
 
 // UpdateNodeWithIsRebootCapableAnnotation updates the is-reboot-capable node annotation to be true if any kind

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -14,9 +14,9 @@ import (
 
 const (
 	// IsRebootCapableAnnotation value is the key name for the node's annotation that will determine if node is reboot capable
-	IsRebootCapableAnnotation        = "is-reboot-capable.self-node-remediation.medik8s.io"
-	IsSoftwareRebootEnabledEnvVar    = "IS_SOFTWARE_REBOOT_ENABLED"
-	IsDefaultConfigurationAnnotation = "is-default-configuration.self-node-remediation.medik8s.io"
+	IsRebootCapableAnnotation          = "is-reboot-capable.self-node-remediation.medik8s.io"
+	IsSoftwareRebootEnabledEnvVar      = "IS_SOFTWARE_REBOOT_ENABLED"
+	IsSingletonConfigurationAnnotation = "is-singleton-configuration.self-node-remediation.medik8s.io"
 )
 
 // UpdateNodeWithIsRebootCapableAnnotation updates the is-reboot-capable node annotation to be true if any kind

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -14,9 +14,8 @@ import (
 
 const (
 	// IsRebootCapableAnnotation value is the key name for the node's annotation that will determine if node is reboot capable
-	IsRebootCapableAnnotation          = "is-reboot-capable.self-node-remediation.medik8s.io"
-	IsSoftwareRebootEnabledEnvVar      = "IS_SOFTWARE_REBOOT_ENABLED"
-	IsSingletonConfigurationAnnotation = "is-singleton-configuration.self-node-remediation.medik8s.io"
+	IsRebootCapableAnnotation     = "is-reboot-capable.self-node-remediation.medik8s.io"
+	IsSoftwareRebootEnabledEnvVar = "IS_SOFTWARE_REBOOT_ENABLED"
 )
 
 // UpdateNodeWithIsRebootCapableAnnotation updates the is-reboot-capable node annotation to be true if any kind


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
SNR has a maximum of one agent created by it's daemonset on each node.
All of these agents are using a single configuration, therefore having more than one configuration may cause an unexpected behavior.
ATM there is no limitation on creating multiple SNR configuration, the purpose of this PR is to make sure there will be no more than one configuration for SNR.


#### Changes made
- Added a unique  annotation on the default configuration.
- Added a validation on creation of a configuration that this annotation exist, otherwise the create is rejected.

#### Which issue(s) this PR fixes
[ECOPROJECT-1997](https://issues.redhat.com//browse/ECOPROJECT-1997)

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
