### PR TITLE
Fix flaky UT

### DIFF
--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -246,22 +246,21 @@ var _ = Describe("SNR Config Test", func() {
 	})
 
 	Context("SNRC defaults", func() {
-		config := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
-		config.Kind = "SelfNodeRemediationConfig"
-		config.APIVersion = "self-node-remediation.medik8s.io/v1alpha1"
-		config.Name = "config-defaults"
-		config.Namespace = shared.Namespace
+		defaultConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
 		BeforeEach(func() {
-			//Config and DS aren't created so no need to clean them
-			isSkipCleanup = true
+			defaultConfig.Kind = "SelfNodeRemediationConfig"
+			defaultConfig.APIVersion = "self-node-remediation.medik8s.io/v1alpha1"
+			//Setting the same name and namespace so it'll be picked up by the AfterEach cleanup
+			defaultConfig.Name = selfnoderemediationv1alpha1.ConfigCRName
+			defaultConfig.Namespace = shared.Namespace
 		})
 
 		It("Config CR should be created with default values", func() {
 			Expect(k8sClient).To(Not(BeNil()))
-			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
+			Expect(k8sClient.Create(context.Background(), defaultConfig)).To(Succeed())
 
 			createdConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
-			configKey := client.ObjectKeyFromObject(config)
+			configKey := client.ObjectKeyFromObject(defaultConfig)
 
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), configKey, createdConfig)

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -202,12 +202,6 @@ var _ = Describe("SNR Config Test", func() {
 					return k8sClient.Get(context.Background(), dsKey, ds)
 				}, 2*time.Second, 250*time.Millisecond).Should(BeNil())
 			}
-			JustBeforeEach(func() {
-				//Wait for Ds to be created
-				Eventually(func(g Gomega) {
-					g.Expect(k8sClient.Get(context.Background(), dsKey, &appsv1.DaemonSet{})).To(Succeed())
-				}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
-			})
 			When("ds version has not changed", func() {
 				BeforeEach(func() {
 					ds = generateDs(dsName, shared.Namespace, currentDsVersion)

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -207,6 +207,8 @@ var _ = Describe("SNR Config Test", func() {
 			var timeToWaitForDsUpdate = 6 * time.Second
 			var oldDsVersion, currentDsVersion = "0", "1"
 			BeforeEach(func() {
+				//Ds needs to be created before the config,
+				//because otherwise the  config creation will also trigger a DS create which will cause a race condition
 				createDsBeforeConfig = true
 			})
 			JustBeforeEach(func() {
@@ -255,6 +257,7 @@ var _ = Describe("SNR Config Test", func() {
 		config.Name = "config-defaults"
 		config.Namespace = shared.Namespace
 		BeforeEach(func() {
+			//Config and DS aren't created so no need to clean them
 			isSkipCleanup = true
 		})
 

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -52,12 +52,17 @@ var _ = Describe("SNR Config Test", func() {
 
 		tmpConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
 		tmpDs := &appsv1.DaemonSet{}
-		//verify ds and config exist
+		//verify config exist
 		Eventually(func(g Gomega) {
-
 			g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(config), tmpConfig)).To(Succeed())
-			g.Expect(k8sClient.Get(context.Background(), dsKey, tmpDs)).To(Succeed())
 		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
+
+		//ds may take quite a while to create (for example with a 5 sec timeout this test usually fails locally)
+		timeToWaitForDSToCreate := 25 * time.Second
+		//verify ds exist
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(context.Background(), dsKey, tmpDs)).To(Succeed())
+		}, timeToWaitForDSToCreate, 250*time.Millisecond).Should(Succeed())
 
 		Expect(k8sClient.Delete(context.TODO(), tmpConfig)).To(Succeed())
 		Expect(k8sClient.Delete(context.TODO(), tmpDs)).To(Succeed())

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -53,24 +53,22 @@ var _ = Describe("SNR Config Test", func() {
 		tmpConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
 		tmpDs := &appsv1.DaemonSet{}
 		//verify ds and config exist
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 
 			g.Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(config), tmpConfig)).To(Succeed())
 			g.Expect(k8sClient.Get(context.Background(), dsKey, tmpDs)).To(Succeed())
-			return true
-		}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 
 		Expect(k8sClient.Delete(context.TODO(), tmpConfig)).To(Succeed())
 		Expect(k8sClient.Delete(context.TODO(), tmpDs)).To(Succeed())
 
 		//verify delete is done
-		Eventually(func(g Gomega) bool {
+		Eventually(func(g Gomega) {
 			err := k8sClient.Get(context.Background(), dsKey, &appsv1.DaemonSet{})
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(config), &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{})
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			return true
-		}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 	})
 
 	Context("DS installation", func() {
@@ -97,12 +95,11 @@ var _ = Describe("SNR Config Test", func() {
 		})
 
 		It("Cert Secret should be created", func() {
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega) {
 				_, _, _, err := certReader.GetCerts()
 				g.Expect(err).ShouldNot(HaveOccurred())
 				g.Expect(k8sClient.Get(context.Background(), dsKey, ds)).To(Succeed())
-				return true
-			}, 15*time.Second, 250*time.Millisecond).Should(BeTrue())
+			}, 15*time.Second, 250*time.Millisecond).Should(Succeed())
 
 		})
 
@@ -134,7 +131,7 @@ var _ = Describe("SNR Config Test", func() {
 				config.Spec.CustomDsTolerations = []corev1.Toleration{expectedToleration}
 			})
 			It("Daemonset should have customized tolerations", func() {
-				Eventually(func(g Gomega) bool {
+				Eventually(func(g Gomega) {
 					ds = &appsv1.DaemonSet{}
 					g.Expect(k8sClient.Get(context.Background(), dsKey, ds)).Should(BeNil())
 
@@ -147,14 +144,13 @@ var _ = Describe("SNR Config Test", func() {
 					g.Expect(string(expectedToleration.Effect)).To(Equal(string(actualToleration.Effect)))
 					g.Expect(string(expectedToleration.Operator)).To(Equal(string(actualToleration.Operator)))
 
-					return true
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 
 				//update configuration
 				config.Spec.PeerUpdateInterval = &metav1.Duration{Duration: time.Second * 10}
 				Expect(k8sClient.Update(context.Background(), config)).To(Succeed())
 
-				Eventually(func(g Gomega) bool {
+				Eventually(func(g Gomega) {
 					ds = &appsv1.DaemonSet{}
 					g.Expect(k8sClient.Get(context.Background(), dsKey, ds)).Should(BeNil())
 
@@ -172,8 +168,7 @@ var _ = Describe("SNR Config Test", func() {
 					g.Expect(string(expectedToleration.Effect)).To(Equal(string(actualToleration.Effect)))
 					g.Expect(string(expectedToleration.Operator)).To(Equal(string(actualToleration.Operator)))
 
-					return true
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 			})
 		})
 		When("SafeTimeToAssumeNodeRebootedSeconds is modified in Configuration", func() {
@@ -182,7 +177,7 @@ var _ = Describe("SNR Config Test", func() {
 				config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 60
 			})
 			It("The Manager Reconciler and the DS should be modified with the new value", func() {
-				Eventually(func(g Gomega) bool {
+				Eventually(func(g Gomega) {
 					ds = &appsv1.DaemonSet{}
 					g.Expect(k8sClient.Get(context.Background(), dsKey, ds)).To(Succeed())
 					dsContainers := ds.Spec.Template.Spec.Containers
@@ -191,8 +186,7 @@ var _ = Describe("SNR Config Test", func() {
 					envVars := getEnvVarMap(container.Env)
 					g.Expect(envVars["TIME_TO_ASSUME_NODE_REBOOTED"].Value).To(Equal("60"))
 					g.Expect(managerReconciler.SafeTimeCalculator.GetTimeToAssumeNodeRebooted()).To(Equal(time.Minute))
-					return true
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 			})
 
 		})
@@ -210,10 +204,9 @@ var _ = Describe("SNR Config Test", func() {
 			}
 			JustBeforeEach(func() {
 				//Wait for Ds to be created
-				Eventually(func(g Gomega) bool {
+				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.Get(context.Background(), dsKey, &appsv1.DaemonSet{})).To(Succeed())
-					return true
-				}, 10*time.Second, 250*time.Millisecond).Should(BeTrue())
+				}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 			})
 			When("ds version has not changed", func() {
 				BeforeEach(func() {

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -36,12 +36,8 @@ var _ = Describe("SNR Config Test", func() {
 		config = &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
 		config.Kind = "SelfNodeRemediationConfig"
 		config.APIVersion = "self-node-remediation.medik8s.io/v1alpha1"
-		config.Spec.WatchdogFilePath = "/dev/foo"
-		config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 123
 		config.Name = selfnoderemediationv1alpha1.ConfigCRName
 		config.Namespace = shared.Namespace
-		config.Spec.HostPort = 30111
-
 	})
 
 	AfterEach(func() {
@@ -77,6 +73,11 @@ var _ = Describe("SNR Config Test", func() {
 	})
 
 	Context("DS installation", func() {
+		BeforeEach(func() {
+			config.Spec.WatchdogFilePath = "/dev/foo"
+			config.Spec.SafeTimeToAssumeNodeRebootedSeconds = 123
+			config.Spec.HostPort = 30111
+		})
 
 		JustBeforeEach(func() {
 			//Creates config which in turn will create the DS
@@ -246,21 +247,13 @@ var _ = Describe("SNR Config Test", func() {
 	})
 
 	Context("SNRC defaults", func() {
-		defaultConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
-		BeforeEach(func() {
-			defaultConfig.Kind = "SelfNodeRemediationConfig"
-			defaultConfig.APIVersion = "self-node-remediation.medik8s.io/v1alpha1"
-			//Setting the same name and namespace so it'll be picked up by the AfterEach cleanup
-			defaultConfig.Name = selfnoderemediationv1alpha1.ConfigCRName
-			defaultConfig.Namespace = shared.Namespace
+		JustBeforeEach(func() {
+			Expect(k8sClient.Create(context.Background(), config)).To(Succeed())
 		})
 
 		It("Config CR should be created with default values", func() {
-			Expect(k8sClient).To(Not(BeNil()))
-			Expect(k8sClient.Create(context.Background(), defaultConfig)).To(Succeed())
-
 			createdConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
-			configKey := client.ObjectKeyFromObject(defaultConfig)
+			configKey := client.ObjectKeyFromObject(config)
 
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), configKey, createdConfig)

--- a/controllers/tests/controller/selfnoderemediation_controller_test.go
+++ b/controllers/tests/controller/selfnoderemediation_controller_test.go
@@ -608,11 +608,11 @@ func verifySelfNodeRemediationPodExist() {
 }
 func deleteRemediations() {
 
-	Eventually(func(g Gomega) bool {
+	Eventually(func(g Gomega) {
 		snrs := &v1alpha1.SelfNodeRemediationList{}
 		g.Expect(k8sClient.List(context.Background(), snrs)).To(Succeed())
 		if len(snrs.Items) == 0 {
-			return true
+			return
 		}
 
 		for _, snr := range snrs.Items {
@@ -626,8 +626,7 @@ func deleteRemediations() {
 		g.Expect(k8sClient.List(context.Background(), expectedEmptySnrs)).To(Succeed())
 		g.Expect(len(expectedEmptySnrs.Items)).To(Equal(0))
 
-		return true
-	}, 10*time.Second, 100*time.Millisecond).Should(BeTrue())
+	}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
 }
 
 func deleteSNR(snr *v1alpha1.SelfNodeRemediation) {


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
improve pipeline stability for shorter dev cycles

#### Changes made
There was a race condition in the test where in some case the daemonset was created twice, it was fixed to make sure it will only happen once.


#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
