### PR TITLE
e2e test improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ protoc-gen-go-grpc: ## Download protoc-gen-go-grpc locally if necessary.
 e2e-test:
 	# KUBECONFIG must be set to the cluster, and PP needs to be deployed already
     # count arg makes the test ignoring cached test results
-	go test ./e2e -ginkgo.v -ginkgo.progress -test.v -timeout 60m -count=1 ${TEST_OPS}
+	go test ./e2e -ginkgo.vv -test.v -timeout 60m -count=1 ${TEST_OPS}
 
 .PHONY: operator-sdk
 OPERATOR_SDK_BIN_FOLDER = ./bin/operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,14 @@ bundle-cleanup: operator-sdk ## Remove bundle installed via bundle-run
 
 .PHONY: create-ns
 create-ns: ## Create namespace
-	$(KUBECTL) get ns $(OPERATOR_NAMESPACE) 2>&1> /dev/null || $(KUBECTL) create ns $(OPERATOR_NAMESPACE)
+	$(KUBECTL) get ns $(OPERATOR_NAMESPACE) 2>&1> /dev/null || \
+		($(KUBECTL) create ns $(OPERATOR_NAMESPACE) && $(MAKE) set-labels-to-namespace)
+
+.PHONY: set-labels-to-namespace
+set-labels-to-namespace: ## Set labels on NS as workaround for OLM pod not running with restricted PSA
+	oc label --overwrite ns $(OPERATOR_NAMESPACE) security.openshift.io/scc.podSecurityLabelSync=false
+	oc label --overwrite ns $(OPERATOR_NAMESPACE) pod-security.kubernetes.io/enforce=privileged
+
 
 ##@ Build
 

--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -84,7 +84,11 @@ var _ = Describe("Self Node Remediation E2E", func() {
 			pod := findSnrPod(healthyNode)
 			logs, err := utils.GetLogs(k8sClientSet, pod)
 			Expect(err).ToNot(HaveOccurred())
-			logger.Info("logs of healthy self-node-remediation pod", "logs", logs)
+			logger.Info("BEGIN logs of healthy self-node-remediation pod", "pod", pod.GetName())
+			for _, line := range strings.Split(logs, "\n") {
+				logger.Info(line)
+			}
+			logger.Info("END logs of healthy self-node-remediation pod", "pod", pod.GetName())
 		})
 
 		Describe("With API connectivity", func() {
@@ -325,7 +329,11 @@ var _ = Describe("Self Node Remediation E2E", func() {
 			pod := findSnrPod(healthyNode)
 			logs, err := utils.GetLogs(k8sClientSet, pod)
 			Expect(err).ToNot(HaveOccurred())
-			logger.Info("logs of healthy self-node-remediation pod", "logs", logs)
+			logger.Info("BEGIN logs of healthy self-node-remediation pod", "pod", pod.GetName())
+			for _, line := range strings.Split(logs, "\n") {
+				logger.Info(line)
+			}
+			logger.Info("END logs of healthy self-node-remediation pod", "pod", pod.GetName())
 		})
 
 		Describe("With API connectivity", func() {
@@ -593,6 +601,7 @@ func restartSnrPods(nodes *v1.NodeList) {
 func restartSnrPod(node *v1.Node) {
 	By("restarting snr pod for resetting logs")
 	pod := findSnrPod(node)
+	ExpectWithOffset(1, pod).ToNot(BeNil())
 
 	//no need to restart the pod
 	for _, cond := range pod.Status.Conditions {
@@ -601,7 +610,6 @@ func restartSnrPod(node *v1.Node) {
 		}
 	}
 
-	ExpectWithOffset(1, pod).ToNot(BeNil())
 	oldPodUID := pod.GetUID()
 
 	deleteAndWait(pod)

--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -79,16 +79,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 		})
 
 		JustAfterEach(func() {
-			By("printing self node remediation log of healthy node")
-			healthyNode := &workers.Items[1]
-			pod := findSnrPod(healthyNode)
-			logs, err := utils.GetLogs(k8sClientSet, pod)
-			Expect(err).ToNot(HaveOccurred())
-			logger.Info("BEGIN logs of healthy self-node-remediation pod", "pod", pod.GetName())
-			for _, line := range strings.Split(logs, "\n") {
-				logger.Info(line)
-			}
-			logger.Info("END logs of healthy self-node-remediation pod", "pod", pod.GetName())
+			printSNRLogsFromNode(&workers.Items[1])
 		})
 
 		Describe("With API connectivity", func() {
@@ -324,16 +315,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 		})
 
 		JustAfterEach(func() {
-			By("printing self node remediation log of healthy node")
-			healthyNode := &controlPlaneNodes.Items[1]
-			pod := findSnrPod(healthyNode)
-			logs, err := utils.GetLogs(k8sClientSet, pod)
-			Expect(err).ToNot(HaveOccurred())
-			logger.Info("BEGIN logs of healthy self-node-remediation pod", "pod", pod.GetName())
-			for _, line := range strings.Split(logs, "\n") {
-				logger.Info(line)
-			}
-			logger.Info("END logs of healthy self-node-remediation pod", "pod", pod.GetName())
+			printSNRLogsFromNode(&controlPlaneNodes.Items[1])
 		})
 
 		Describe("With API connectivity", func() {
@@ -673,4 +655,16 @@ func ensureSnrRunning(nodes *v1.NodeList) {
 		}()
 	}
 	wg.Wait()
+}
+
+func printSNRLogsFromNode(node *v1.Node) {
+	By("printing self node remediation log of healthy node")
+	pod := findSnrPod(node)
+	logs, err := utils.GetLogs(k8sClientSet, pod)
+	Expect(err).ToNot(HaveOccurred())
+	logger.Info("BEGIN logs of healthy self-node-remediation pod", "name", pod.GetName())
+	for _, line := range strings.Split(logs, "\n") {
+		logger.Info(line)
+	}
+	logger.Info("END logs of healthy self-node-remediation pod", "name", pod.GetName())
 }


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
This PR introduces some required and nice-to-have improvements to E2E tests

#### Changes made
<!-- Outline the specific changes made in this merge request. -->

- Replace deprecated ginko progress with increased verbosity
- Improve logging
- Set labels for unrestricted PSA on namespace



#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.

In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
