### PR TITLE
Increase timeout on deleteAndWait in e2e

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -649,7 +649,7 @@ func deleteAndWait(resource client.Object) {
 			return true
 		}
 		return false
-	}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "resource not deleted in time")
+	}, 4*time.Minute, 10*time.Second).Should(BeTrue(), "resource not deleted in time")
 }
 
 func ensureSnrRunning(nodes *v1.NodeList) {


### PR DESCRIPTION
#### Why we need this PR
Flaky e2e

#### Changes made
Increase timeout on deleteAndWait in e2e.
This used for deleting SNR CRs, which only works when remediation is done, which can take longer than 2 min.
