### PR TITLE
Remove unused variable `isSkipCleanup`

### DIFF
--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -29,18 +29,12 @@ var _ = Describe("SNR Config Test", func() {
 		Namespace: shared.Namespace,
 		Name:      dsName,
 	}
-	var isSkipCleanup bool
 	BeforeEach(func() {
 		ds = &appsv1.DaemonSet{}
 		config = shared.GenerateTestConfig()
 	})
 
 	AfterEach(func() {
-		if isSkipCleanup {
-			isSkipCleanup = false
-			return
-		}
-
 		tmpConfig := &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{}
 		tmpDs := &appsv1.DaemonSet{}
 		//verify config exist


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
This variable was used in an[ early stage](https://github.com/medik8s/self-node-remediation/pull/204/commits/c220fcfe77ec17d7811a1e1085124f15ec14ee0b#diff-91365162a1d1121a55c65ac4980e04d17aa1dead56aaa10a688b2032de96a831R258) of #204, the final merged version of that  PR didn't use this variable making it redundant, so it should be removed.

#### Changes made
removing unused variable


#### Which issue(s) this PR fixes
Technical debt


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
