### PR TITLE
Fix calculator lock and unit test

### DIFF
--- a/pkg/reboot/calculator.go
+++ b/pkg/reboot/calculator.go
@@ -55,11 +55,10 @@ func (r *calculator) SetConfig(config *v1alpha1.SelfNodeRemediationConfig) {
 	r.snrConfig = config
 }
 
-// TODO add unit test!
 func (r *calculator) GetRebootDuration(ctx context.Context, node *v1.Node) (time.Duration, error) {
 
-	r.snrConfigLock.Lock()
-	defer r.snrConfigLock.Unlock()
+	r.snrConfigLock.RLock()
+	defer r.snrConfigLock.RUnlock()
 	if r.snrConfig == nil {
 		return 0, errors.New("SelfNodeRemediationConfig not set yet, can't calculate minimum reboot duration")
 	}

--- a/pkg/reboot/calculator_test.go
+++ b/pkg/reboot/calculator_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Calculator tests", func() {
 		It("GetRebootTime should return correct value", func() {
 			Eventually(func() (time.Duration, error) {
 				return calculator.GetRebootDuration(context.Background(), unhealthyNode)
-			}, "5s", "200ms").Should(Equal(time.Duration(expectedRebootDurationSeconds) * time.Second))
+			}, "15s", "200ms").Should(Equal(time.Duration(expectedRebootDurationSeconds) * time.Second))
 		})
 	})
 
@@ -114,7 +114,7 @@ var _ = Describe("Calculator tests", func() {
 		It("GetRebootTime should return correct value", func() {
 			Eventually(func() (time.Duration, error) {
 				return calculator.GetRebootDuration(context.Background(), unhealthyNode)
-			}, "5s", "200ms").Should(Equal(time.Duration(expectedRebootDurationSeconds) * time.Second))
+			}, "15s", "200ms").Should(Equal(time.Duration(expectedRebootDurationSeconds) * time.Second))
 		})
 	})
 })


### PR DESCRIPTION
#### Why we need this PR

calculator unit test times out sometimes because config wasn't set yet

#### Changes made

- fix lock when reading only (will probably have no significant effect though)
- increase unit test timeout to wait for config being set in calculator
