### PR TITLE
Fix log message

### DIFF
--- a/pkg/reboot/calculator.go
+++ b/pkg/reboot/calculator.go
@@ -78,7 +78,7 @@ func (r *calculator) GetRebootDuration(ctx context.Context, node *v1.Node) (time
 	specRebootDurationSeconds := r.snrConfig.Spec.SafeTimeToAssumeNodeRebootedSeconds
 	if specRebootDurationSeconds == nil {
 		r.log.Info("No SafeTimeToAssumeNodeRebootedSeconds specified, using calculated minimum safe reboot time",
-			"calculated minimum time in seconds", minimumCalculatedRebootDuration)
+			"calculated minimum time in seconds", minimumCalculatedRebootDuration.Seconds())
 		return minimumCalculatedRebootDuration, nil
 	}
 


### PR DESCRIPTION
#### Why we need this PR
Slightly wrong log message:

`2024-07-05T06:32:29.280007573Z	INFO	rebootDurationCalculator	No SafeTimeToAssumeNodeRebootedSeconds specified, using calculated minimum safe reboot time	{"calculated minimum time in seconds": "2m0s"}`

Should be `120` instead of `2m0s`

#### Changes made
Take `Seconds()` from duration in log

Fixes [ECOPROJECT-2025](https://issues.redhat.com//browse/ECOPROJECT-2025)
