### PR TITLE
Retry setting Out Of Service flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -141,7 +142,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
+	interval := 2 * time.Second // retry every 2 seconds
+	timeout := 10 * time.Second // for a period of 10 seconds
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Using wait.PollUntilContextTimeout to retry InitOutOfServiceTaintFlags in case there is a temporary network issue.
+	// Since the last internal error returned by InitOutOfServiceTaintFlags also indicates whether polling succeed or not, there is no need to also keep the context error returned by PollUntilContextTimeout.
+	_ = wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
+		if err = utils.InitOutOfServiceTaintFlags(mgr.GetConfig()); err != nil {
+			return false, nil // Keep retrying
+		}
+		return true, nil // Success
+	})
+
+	if err != nil {
 		setupLog.Error(err, "unable to verify out-of-service taint support. out-of-service taint isn't supported")
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
During release testing of SNR we've noticed one case were SNR template with Out Of Service taint strategy could not be created.
The reason for that was that because when SNR was initialized,  it failed to fetch the k8s version therefore SNR couldn't verify support for Out Of Service taint.
We couldn't reproduce this, but we suspect this occurred due to a temporary network issue. 
In order to minimize similar occurrences in the future a retry mechanism is added.

Adding links to our slack discussion on that subject. [[1]](https://redhat-internal.slack.com/archives/C03M5GKJNBA/p1720704425398739) [[2]](https://redhat-internal.slack.com/archives/C03M5GKJNBA/p1720809806541209)

#### Changes made
In case Out Of Service flags can't be set at the first attempt (due to failing getting the k8s version or any other reason) , several retries will be made before deciding Out Of Service flags isn't supported.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
