### PR TITLE
Fix Deletion timestamp check

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -807,7 +807,7 @@ func (r *SelfNodeRemediationReconciler) removeNoExecuteTaint(node *v1.Node) erro
 }
 
 func (r *SelfNodeRemediationReconciler) isStoppedByNHC(snr *v1alpha1.SelfNodeRemediation) bool {
-	if snr != nil && snr.Annotations != nil && snr.DeletionTimestamp == nil {
+	if snr != nil && snr.Annotations != nil {
 		_, isTimeoutIssued := snr.Annotations[nhcTimeOutAnnotation]
 		return isTimeoutIssued
 	}


### PR DESCRIPTION

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
SNR should allow removal of redundant remediations - a remediation of a node that no longer exist since MDR deleted the node and triggered a provisioning of a new one.
Currently there is a bug in the code which prevents SNR reaching that logic, this PR fixes it.

#### Changes made
When SNR detects a remediation that is both deleted and marked as Timeout by NHC it should remove the finilizer. 
This PR removed an unnecessary check of the CR deletion timestamp that preceded this logic and prevented reaching this logic and the removal of the finilizer.


#### Which issue(s) this PR fixes
[ECOPROJECT-2489](https://issues.redhat.com//browse/ECOPROJECT-2489)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
