### PR TITLE
Fix watchdog usage in controller unit tests

### DIFF
--- a/controllers/tests/controller/suite_test.go
+++ b/controllers/tests/controller/suite_test.go
@@ -54,7 +54,7 @@ import (
 
 var (
 	testEnv                 *envtest.Environment
-	dummyDog                watchdog.Watchdog
+	dummyDog                watchdog.FakeWatchdog
 	unhealthyNode, peerNode = &v1.Node{}, &v1.Node{}
 	cancelFunc              context.CancelFunc
 	k8sClient               *shared.K8sClientWrapper

--- a/pkg/watchdog/fake.go
+++ b/pkg/watchdog/fake.go
@@ -11,14 +11,22 @@ const (
 	fakeTimeout = 1 * time.Second
 )
 
+type FakeWatchdog interface {
+	Watchdog
+	Reset()
+}
+
 // fakeWatchdogImpl provides the fake implementation of the watchdogImpl interface for tests
 type fakeWatchdogImpl struct {
 	IsStartSuccessful bool
+	*synchronizedWatchdog
 }
 
-func NewFake(isStartSuccessful bool) Watchdog {
+func NewFake(isStartSuccessful bool) FakeWatchdog {
 	fakeWDImpl := &fakeWatchdogImpl{IsStartSuccessful: isStartSuccessful}
-	return newSynced(ctrl.Log.WithName("fake watchdog"), fakeWDImpl)
+	syncedWD := newSynced(ctrl.Log.WithName("fake watchdog"), fakeWDImpl)
+	fakeWDImpl.synchronizedWatchdog = syncedWD
+	return fakeWDImpl
 }
 
 func (f *fakeWatchdogImpl) start() (*time.Duration, error) {
@@ -35,4 +43,15 @@ func (f *fakeWatchdogImpl) feed() error {
 
 func (f *fakeWatchdogImpl) disarm() error {
 	return nil
+}
+
+func (f *fakeWatchdogImpl) Reset() {
+	swd := f.synchronizedWatchdog
+	swd.mutex.Lock()
+	defer swd.mutex.Unlock()
+	if swd.status != Armed {
+		swd.stop()
+		swd.status = Armed
+		swd.startFeeding()
+	}
 }

--- a/pkg/watchdog/watchdog_suite_test.go
+++ b/pkg/watchdog/watchdog_suite_test.go
@@ -1,0 +1,13 @@
+package watchdog_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWatchdog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Watchdog Suite")
+}

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("Watchdog", func() {
 
-	var wd watchdog.Watchdog
+	var wd watchdog.FakeWatchdog
 	var cancel context.CancelFunc
 
 	BeforeEach(func() {
@@ -63,6 +63,20 @@ var _ = Describe("Watchdog", func() {
 				g.Expect(wd.Status()).To(Equal(watchdog.Disarmed))
 			}, 1*time.Second, 100*time.Millisecond).Should(Succeed(), "watchdog should be disarmed")
 			verifyNoWatchdogFood(wd)
+		})
+	})
+
+	Context("Triggered watchdog reset", func() {
+		BeforeEach(func() {
+			wd.Stop()
+			wd.Reset()
+		})
+
+		It("should be armed and fed", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(wd.Status()).To(Equal(watchdog.Armed))
+			}, 1*time.Second, 100*time.Millisecond).Should(Succeed(), "watchdog should be armed")
+			verifyWatchdogFood(wd)
 		})
 	})
 })

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -1,0 +1,82 @@
+package watchdog_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/medik8s/self-node-remediation/pkg/watchdog"
+)
+
+var _ = Describe("Watchdog", func() {
+
+	var wd watchdog.Watchdog
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		var ctx context.Context
+		ctx, cancel = context.WithCancel(context.Background())
+
+		wd = watchdog.NewFake(true)
+		Expect(wd).NotTo(BeNil())
+		go func() {
+			err := wd.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
+		Eventually(func(g Gomega) {
+			g.Expect(wd.Status()).To(Equal(watchdog.Armed))
+		}, 1*time.Second, 100*time.Millisecond).Should(Succeed(), "watchdog should be armed")
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Context("Watchdog started", func() {
+		It("should be fed", func() {
+			verifyWatchdogFood(wd)
+		})
+	})
+
+	Context("Watchdog triggered", func() {
+		BeforeEach(func() {
+			wd.Stop()
+		})
+
+		It("should be triggered and not be fed anymore", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(wd.Status()).To(Equal(watchdog.Triggered))
+			}, 1*time.Second, 100*time.Millisecond).Should(Succeed(), "watchdog should be triggered")
+			verifyNoWatchdogFood(wd)
+		})
+	})
+
+	Context("Watchdog cancelled", func() {
+		BeforeEach(func() {
+			cancel()
+		})
+
+		It("should be disarmed and and not be fed anymore", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(wd.Status()).To(Equal(watchdog.Disarmed))
+			}, 1*time.Second, 100*time.Millisecond).Should(Succeed(), "watchdog should be disarmed")
+			verifyNoWatchdogFood(wd)
+		})
+	})
+})
+
+func verifyWatchdogFood(wd watchdog.Watchdog) {
+	currentLastFoodTime := wd.LastFoodTime()
+	EventuallyWithOffset(1, func() time.Time {
+		return wd.LastFoodTime()
+	}, wd.GetTimeout(), 100*time.Millisecond).Should(BeTemporally(">", currentLastFoodTime), "watchdog should receive food")
+}
+
+func verifyNoWatchdogFood(wd watchdog.Watchdog) {
+	currentLastFoodTime := wd.LastFoodTime()
+	ConsistentlyWithOffset(1, func() time.Time {
+		return wd.LastFoodTime()
+	}, 5*wd.GetTimeout(), 1*time.Second).Should(Equal(currentLastFoodTime), "watchdog should not receive food anymore")
+}


### PR DESCRIPTION
#### Why we need this PR
Controller unit tests are broken. They have false positives because they all use the same watchdog.
Also, one unit test is testing for the wrong result.

#### Changes made
- fix error handling in peers component
- add unit test for watchdog
- fixed issues in controller unit test

For details see commit messages.

#### Which issue(s) this PR fixes
Fixes issues with #238 

#### Test plan
There are new and fixed tests