### PR TITLE
Update peer timeout logic

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -94,7 +94,7 @@ type SelfNodeRemediationConfigSpec struct {
 
 	// Timeout for each peer request.
 	// Valid time units are "ms", "s", "m", "h".
-	// +kubebuilder:default:="5s"
+	// +kubebuilder:default:="7s"
 	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	// +kubebuilder:validation:Type:=string
 	// +optional

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -212,7 +212,7 @@ func (r *SelfNodeRemediationConfig) validatePeerTimeoutSafety() admission.Warnin
 			"PeerRequestTimeout (%s) is less than ApiServerTimeout + MinimumBuffer (%s + %s = %s). "+
 				"This configuration may lead to race conditions where peer health checks time out "+
 				"before API server checks complete, potentially causing premature remediation. "+
-				"Consider increasing PeerRequestTimeout to at least %s for safer operation.",
+				"Overriding PeerRequestTimeout to %s for safer operation.",
 			peerRequestTimeoutDuration,
 			apiServerTimeoutDuration,
 			MinimumBuffer,
@@ -220,7 +220,7 @@ func (r *SelfNodeRemediationConfig) validatePeerTimeoutSafety() admission.Warnin
 			minimumSafePeerTimeout,
 		)
 		warnings = append(warnings, warningMsg)
-		selfNodeRemediationConfigLog.Info("PeerRequestTimeout safety warning",
+		selfNodeRemediationConfigLog.Info("PeerRequestTimeout safety warning, overriding PeerRequestTimeout to minimumSafeTimeout",
 			"peerRequestTimeout", peerRequestTimeoutDuration,
 			"apiServerTimeout", apiServerTimeoutDuration,
 			"minimumSafeTimeout", minimumSafePeerTimeout)

--- a/api/v1alpha1/selfnoderemediationconfig_webhook.go
+++ b/api/v1alpha1/selfnoderemediationconfig_webhook.go
@@ -49,6 +49,10 @@ const (
 	minDurPeerRequestTimeout   = 10 * time.Millisecond
 	minDurApiCheckInterval     = 1 * time.Second
 	minDurPeerUpdateInterval   = 10 * time.Second
+
+	// MinimumBuffer is the minimum buffer time between APIServerTimeout and PeerRequestTimeout
+	// It is required to make sure there is enough time for network communication between the peers in case the API Server is out
+	MinimumBuffer = 2 * time.Second
 )
 
 type field struct {
@@ -74,7 +78,9 @@ var _ webhook.Validator = &SelfNodeRemediationConfig{}
 func (r *SelfNodeRemediationConfig) ValidateCreate() (warning admission.Warnings, err error) {
 	selfNodeRemediationConfigLog.Info("validate create", "name", r.Name)
 
-	return admission.Warnings{}, errors.NewAggregate([]error{
+	warnings := r.validatePeerTimeoutSafety()
+
+	return warnings, errors.NewAggregate([]error{
 		r.validateTimes(),
 		r.validateCustomTolerations(),
 		r.validateSingleton(),
@@ -86,7 +92,9 @@ func (r *SelfNodeRemediationConfig) ValidateCreate() (warning admission.Warnings
 func (r *SelfNodeRemediationConfig) ValidateUpdate(_ runtime.Object) (warning admission.Warnings, err error) {
 	selfNodeRemediationConfigLog.Info("validate update", "name", r.Name)
 
-	return admission.Warnings{}, errors.NewAggregate([]error{
+	warnings := r.validatePeerTimeoutSafety()
+
+	return warnings, errors.NewAggregate([]error{
 		r.validateTimes(),
 		r.validateCustomTolerations(),
 	})
@@ -182,6 +190,43 @@ func validateToleration(toleration v1.Toleration) error {
 		}
 	}
 	return nil
+}
+
+// validatePeerTimeoutSafety checks if PeerRequestTimeout is safe relative to ApiServerTimeout
+// and returns warnings if the configuration might be unsafe
+func (r *SelfNodeRemediationConfig) validatePeerTimeoutSafety() admission.Warnings {
+	var warnings admission.Warnings
+
+	spec := r.Spec
+	if spec.PeerRequestTimeout == nil || spec.ApiServerTimeout == nil {
+		// Use defaults if not specified
+		return warnings
+	}
+
+	peerRequestTimeoutDuration := spec.PeerRequestTimeout.Duration
+	apiServerTimeoutDuration := spec.ApiServerTimeout.Duration
+	minimumSafePeerTimeout := apiServerTimeoutDuration + MinimumBuffer
+
+	if peerRequestTimeoutDuration < minimumSafePeerTimeout {
+		warningMsg := fmt.Sprintf(
+			"PeerRequestTimeout (%s) is less than ApiServerTimeout + MinimumBuffer (%s + %s = %s). "+
+				"This configuration may lead to race conditions where peer health checks time out "+
+				"before API server checks complete, potentially causing premature remediation. "+
+				"Consider increasing PeerRequestTimeout to at least %s for safer operation.",
+			peerRequestTimeoutDuration,
+			apiServerTimeoutDuration,
+			MinimumBuffer,
+			minimumSafePeerTimeout,
+			minimumSafePeerTimeout,
+		)
+		warnings = append(warnings, warningMsg)
+		selfNodeRemediationConfigLog.Info("PeerRequestTimeout safety warning",
+			"peerRequestTimeout", peerRequestTimeoutDuration,
+			"apiServerTimeout", apiServerTimeoutDuration,
+			"minimumSafeTimeout", minimumSafePeerTimeout)
+	}
+
+	return warnings
 }
 
 func (r *SelfNodeRemediationConfig) validateSingleton() error {

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -153,7 +153,7 @@ spec:
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               peerRequestTimeout:
-                default: 5s
+                default: 7s
                 description: |-
                   Timeout for each peer request.
                   Valid time units are "ms", "s", "m", "h".

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -151,7 +151,7 @@ spec:
                 pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               peerRequestTimeout:
-                default: 5s
+                default: 7s
                 description: |-
                   Timeout for each peer request.
                   Valid time units are "ms", "s", "m", "h".

--- a/controllers/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/controllers/tests/config/selfnoderemediationconfig_controller_test.go
@@ -233,7 +233,7 @@ var _ = Describe("SNR Config Test", func() {
 			Expect(createdConfig.Spec.MaxApiErrorThreshold).To(Equal(3))
 
 			Expect(createdConfig.Spec.PeerApiServerTimeout.Seconds()).To(BeEquivalentTo(5))
-			Expect(createdConfig.Spec.PeerRequestTimeout.Seconds()).To(BeEquivalentTo(5))
+			Expect(createdConfig.Spec.PeerRequestTimeout.Seconds()).To(BeEquivalentTo(7))
 			Expect(createdConfig.Spec.PeerDialTimeout.Seconds()).To(BeEquivalentTo(5))
 			Expect(createdConfig.Spec.ApiServerTimeout.Seconds()).To(BeEquivalentTo(5))
 			Expect(createdConfig.Spec.ApiCheckInterval.Seconds()).To(BeEquivalentTo(15))

--- a/main.go
+++ b/main.go
@@ -344,6 +344,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 		PeerRequestTimeout:        peerRequestTimeout,
 		PeerHealthPort:            peerHealthDefaultPort,
 		MaxTimeForNoPeersResponse: reboot.MaxTimeForNoPeersResponse,
+		Recorder:                  mgr.GetEventRecorderFor("ApiConnectivityCheck"),
 	}
 
 	controlPlaneManager := controlplane.NewManager(myNodeName, mgr.GetClient())
@@ -377,7 +378,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 
 	setupLog.Info("init grpc server")
 	// TODO make port configurable?
-	server, err := peerhealth.NewServer(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("peerhealth").WithName("server"), peerHealthDefaultPort, certReader)
+	server, err := peerhealth.NewServer(mgr.GetClient(), mgr.GetAPIReader(), ctrl.Log.WithName("peerhealth").WithName("server"), peerHealthDefaultPort, certReader, apiServerTimeout)
 	if err != nil {
 		setupLog.Error(err, "failed to init grpc server")
 		os.Exit(1)

--- a/pkg/apicheck/check_test.go
+++ b/pkg/apicheck/check_test.go
@@ -1,0 +1,83 @@
+package apicheck
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/medik8s/self-node-remediation/api/v1alpha1"
+)
+
+func TestApiCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ApiCheck Suite")
+}
+
+var _ = Describe("ApiConnectivityCheck", func() {
+	var (
+		apiCheck     *ApiConnectivityCheck
+		config       *ApiConnectivityCheckConfig
+		fakeRecorder *record.FakeRecorder
+		log          logr.Logger
+	)
+
+	BeforeEach(func() {
+		log = ctrl.Log.WithName("test")
+		fakeRecorder = record.NewFakeRecorder(10)
+
+		config = &ApiConnectivityCheckConfig{
+			Log:                log,
+			MyNodeName:         "test-node",
+			ApiServerTimeout:   5 * time.Second,
+			PeerRequestTimeout: 7 * time.Second,
+			Recorder:           fakeRecorder,
+		}
+
+		apiCheck = &ApiConnectivityCheck{
+			config: config,
+		}
+	})
+
+	Describe("getEffectivePeerRequestTimeout", func() {
+		Context("when PeerRequestTimeout is safe", func() {
+			It("should return the configured PeerRequestTimeout", func() {
+				// ApiServerTimeout=5s, PeerRequestTimeout=7s, MinimumBuffer=2s
+				// 7s >= (5s + 2s), so it's safe
+				effectiveTimeout := apiCheck.getEffectivePeerRequestTimeout()
+
+				Expect(effectiveTimeout).To(Equal(7 * time.Second))
+
+				// Should not emit any events
+				Expect(len(fakeRecorder.Events)).To(Equal(0))
+			})
+		})
+
+		Context("when PeerRequestTimeout is unsafe", func() {
+			It("should return adjusted timeout and emit warning event", func() {
+				config.PeerRequestTimeout = 6 * time.Second // Less than 5s + 2s = 7s
+
+				effectiveTimeout := apiCheck.getEffectivePeerRequestTimeout()
+
+				expectedMinimumTimeout := config.ApiServerTimeout + v1alpha1.MinimumBuffer // 7s
+				Expect(effectiveTimeout).To(Equal(expectedMinimumTimeout))
+
+				// Should emit a warning event
+				Expect(len(fakeRecorder.Events)).To(Equal(1))
+				event := <-fakeRecorder.Events
+				Expect(event).To(ContainSubstring("Warning"))
+				Expect(event).To(ContainSubstring("PeerTimeoutAdjusted"))
+				Expect(event).To(ContainSubstring("6s")) // configured timeout
+				Expect(event).To(ContainSubstring("5s")) // API server timeout
+				Expect(event).To(ContainSubstring("7s")) // safe timeout
+			})
+
+		})
+
+	})
+})

--- a/pkg/peerhealth/client_server_test.go
+++ b/pkg/peerhealth/client_server_test.go
@@ -23,8 +23,9 @@ var _ = Describe("Checking health using grpc client and server", func() {
 	var phServer *Server
 	var cancel context.CancelFunc
 	var phClient *Client
+	var apiServerTimeout = 5 * time.Second
 
-	BeforeEach(func() {
+	JustBeforeEach(func() {
 
 		By("creating test node")
 		node := &v1.Node{
@@ -49,7 +50,7 @@ var _ = Describe("Checking health using grpc client and server", func() {
 		}
 
 		By("Creating server")
-		phServer, err = NewServer(k8sClient, reader, ctrl.Log.WithName("peerhealth test").WithName("phServer"), 9000, certReader, 7*time.Second)
+		phServer, err = NewServer(k8sClient, reader, ctrl.Log.WithName("peerhealth test").WithName("phServer"), 9000, certReader, apiServerTimeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Starting server")
@@ -132,15 +133,18 @@ var _ = Describe("Checking health using grpc client and server", func() {
 
 		BeforeEach(func() {
 			reader.delay = &apiCallDelay
+			apiServerTimeout = 3 * time.Second
+
 		})
 
 		AfterEach(func() {
 			reader.delay = nil
+			apiServerTimeout = 5 * time.Second
 		})
 
 		It("should return API error", func() {
 			By("calling isHealthy")
-			// The health server code has a hardcoded timeout of 3s for the API call!
+			// The health server code has a timeout of 3s for the API call!
 			// When we add a delay of > 3s to the API call, that 3s timeout needs to be respected,
 			// to not exceed the peerRequestTimeout (5s) of the client.
 			ctx, cancel := context.WithTimeout(context.Background(), peerRequestTimeout)

--- a/pkg/peerhealth/client_server_test.go
+++ b/pkg/peerhealth/client_server_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Checking health using grpc client and server", func() {
 		}
 
 		By("Creating server")
-		phServer, err = NewServer(k8sClient, reader, ctrl.Log.WithName("peerhealth test").WithName("phServer"), 9000, certReader)
+		phServer, err = NewServer(k8sClient, reader, ctrl.Log.WithName("peerhealth test").WithName("phServer"), 9000, certReader, 7*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Starting server")

--- a/pkg/peerhealth/server.go
+++ b/pkg/peerhealth/server.go
@@ -154,18 +154,6 @@ func (s *Server) listWithTimeoutHandling(apiCtx context.Context, snrs *v1alpha1.
 	}
 }
 
-func (s *Server) getNode(ctx context.Context, nodeName string) (*corev1.Node, error) {
-	apiCtx, cancelFunc := context.WithTimeout(ctx, s.apiServerTimeout)
-	defer cancelFunc()
-
-	node := &corev1.Node{}
-	if err := s.c.Get(apiCtx, client.ObjectKey{Name: nodeName}, node); err != nil {
-		s.log.Error(err, "api error")
-		return nil, err
-	}
-	return node, nil
-}
-
 func toResponse(status selfNodeRemediationApis.HealthCheckResponseCode) (*HealthResponse, error) {
 	return &HealthResponse{
 		Status: int32(status),

--- a/pkg/peerhealth/server.go
+++ b/pkg/peerhealth/server.go
@@ -21,10 +21,6 @@ import (
 
 const (
 	connectionTimeout = 5 * time.Second
-	//IMPORTANT! this MUST be less than PeerRequestTimeout in apicheck
-	//The difference between them should allow some time for sending the request over the network
-	//todo enforce this
-	apiServerTimeout = 3 * time.Second
 )
 
 var (
@@ -42,21 +38,23 @@ var (
 
 type Server struct {
 	UnimplementedPeerHealthServer
-	c          client.Client
-	reader     client.Reader
-	log        logr.Logger
-	certReader certificates.CertStorageReader
-	port       int
+	c                client.Client
+	reader           client.Reader
+	log              logr.Logger
+	certReader       certificates.CertStorageReader
+	port             int
+	apiServerTimeout time.Duration
 }
 
 // NewServer returns a new Server
-func NewServer(c client.Client, reader client.Reader, log logr.Logger, port int, certReader certificates.CertStorageReader) (*Server, error) {
+func NewServer(c client.Client, reader client.Reader, log logr.Logger, port int, certReader certificates.CertStorageReader, apiServerTimeout time.Duration) (*Server, error) {
 	return &Server{
-		c:          c,
-		reader:     reader,
-		log:        log,
-		certReader: certReader,
-		port:       port,
+		c:                c,
+		reader:           reader,
+		log:              log,
+		certReader:       certReader,
+		port:             port,
+		apiServerTimeout: apiServerTimeout,
 	}, nil
 }
 
@@ -109,7 +107,7 @@ func (s *Server) IsHealthy(ctx context.Context, request *HealthRequest) (*Health
 		return nil, fmt.Errorf("empty node name in HealthRequest")
 	}
 
-	apiCtx, cancelFunc := context.WithTimeout(ctx, apiServerTimeout)
+	apiCtx, cancelFunc := context.WithTimeout(ctx, s.apiServerTimeout)
 	defer cancelFunc()
 
 	snrs := &v1alpha1.SelfNodeRemediationList{}
@@ -157,7 +155,7 @@ func (s *Server) listWithTimeoutHandling(apiCtx context.Context, snrs *v1alpha1.
 }
 
 func (s *Server) getNode(ctx context.Context, nodeName string) (*corev1.Node, error) {
-	apiCtx, cancelFunc := context.WithTimeout(ctx, apiServerTimeout)
+	apiCtx, cancelFunc := context.WithTimeout(ctx, s.apiServerTimeout)
 	defer cancelFunc()
 
 	node := &corev1.Node{}


### PR DESCRIPTION

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
This PR address one of the issues found in [ECOPROJECT-2642](https://issues.redhat.com/browse/ECOPROJECT-2642)

The following in particular:
ATM apiServerTimeout is hard coded to 3 s
The reason that it is hardcoded to begin with is because both APIServerTimeout and PeerTimeout defaulted to 5 seconds. This might have created a scenario where Node A might time out waiting for a peer health check from Node B, while Node B is simultaneously experiencing a slow API server response. 
In that scenario Node A might have initiating remediation prematurely, assuming a network issue, when the actual problem is API server slowness.

The focus of the fix is:
- removing the hard coded apiServerTimeout value
- making sure we avoid the described scenario by updating the PeerTimeout value and overriding it in case an invalid value is used.



#### Changes made
- updated the default PeerTimeout value to a higher, safer value (e.g., 7 seconds).
- added a validating admission webhook that issues a warning if the configured PeerTimeout is less than APIServerTimeout + MinimumBuffer (e.g., 2 seconds).
- if the configured PeerTimeout is less than APIServerTimeout + MinimumBuffer, the operator will internally use APIServerTimeout + MinimumBuffer for the peer check.


#### Which issue(s) this PR fixes
[ECOPROJECT-2642](https://issues.redhat.com//browse/ECOPROJECT-2642)


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added safety validation and warnings if the peer request timeout is set too low compared to the API server timeout, helping prevent premature remediation actions.
  - Improved event recording and logging for timeout adjustments to enhance observability.

- **Bug Fixes**
  - Ensured peer request timeout is never set below a safe minimum relative to the API server timeout.

- **Chores**
  - Updated default peer request timeout from 5 seconds to 7 seconds across configuration, documentation, and tests to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->