### PR TITLE
Change Deployment UpdateStrategy

### DIFF
--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -273,7 +273,11 @@ spec:
             matchLabels:
               control-plane: controller-manager
               self-node-remediation-operator: ""
-          strategy: {}
+          strategy:
+            rollingUpdate:
+              maxSurge: 0
+              maxUnavailable: 1
+            type: RollingUpdate
           template:
             metadata:
               labels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,11 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### Why we need this PR

- After new placement rule introduced in #180, the manager pods can only be scheduled on two specific nodes. Under these conditions, the default strategy may cause rollout deadlocks during node recovery.
- Certificate rotation managed by OLM can trigger Deployment rollouts by changing the `olmcahash` annotation. With the current strategy, this may lead to deadlocks if a node is down during recovery, causing rollout failures. To improve reliability and ensure safe updates under these conditions, we need a more controlled approach.

#### Changes made
- Added `RollingUpdate` strategy with `maxSurge: 0` and `maxUnavailable: 1` for safer deployment updates.

- Before (default): When a rollout starts, the Deployment tries to keep the old pod until the new one is ready. On clusters with only 2 nodes, this can fail because there is no room to schedule the new pod, leading to a stuck rollout.

- After: Pods are updated one at a time. The controller deletes one pod first, then creates a new one, ensuring that rollout can proceed safely even when only 2 nodes are available.


#### Which issue(s) this PR fixes

[RHWA-366](https://issues.redhat.com/browse/RHWA-366)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment strategy configuration for controller-manager components to implement RollingUpdate strategy with specified constraints on pod surges and allowed unavailability. These operational improvements ensure more controlled and stable application updates while maintaining better service availability throughout upgrade processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->