### PR TITLE
Configurable E2E Namespace by Environment Variable

### DIFF
--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	Expect(err).NotTo(HaveOccurred())
 
 	cfg, err = config.GetConfig()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Couldn't get kubeconfig")
 	Expect(cfg).ToNot(BeNil())
 
 	k8sClient, err = client.New(cfg, client.Options{})


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

- Testing the E2E code would fail when the SNR is installed in another namespace other than the hardcoded namespace `self-node-remediation` .

See below the error from testing.
```
  [FAILED] Timed out after 300.009s.
  Could not get boot time on target node
  Unexpected error:
      <*errors.StatusError | 0xc00025eaa0>: 
      namespaces "self-node-remediation" not found
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "namespaces \"self-node-remediation\" not found",
              Reason: "NotFound",
              Details: {
                  Name: "self-node-remediation",
                  Group: "",
                  Kind: "namespaces",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 404,
          },
      }
  occurred
```
- Provide a meaningful error on missing kubeconfig
#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- Set and fetch the operator-installed namespace by the env var `OPERATOR_NS`, and when it is missing, use the default value `self-node-remediation`.
- Use a text to describe a missing kubeconfig before running the e2e tests
#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite now supports runtime selection of the test namespace via an environment variable with a configurable default, and logs which value is used.
  * Improved initialization checks and clearer error handling when acquiring cluster configuration during test setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->