### PR TITLE
Avoid Marking the Node as Unscheduleable

### DIFF
--- a/controllers/selfnoderemediation_controller.go
+++ b/controllers/selfnoderemediation_controller.go
@@ -52,12 +52,10 @@ const (
 
 	// remediation
 	eventReasonAddFinalizer                 = "AddFinalizer"
-	eventReasonMarkUnschedulable            = "MarkUnschedulable"
 	eventReasonAddNoExecute                 = "AddNoExecute"
 	eventReasonAddOutOfService              = "AddOutOfService"
 	eventReasonUpdateTimeAssumedRebooted    = "UpdateTimeAssumedRebooted"
 	eventReasonDeleteResources              = "DeleteResources"
-	eventReasonMarkSchedulable              = "MarkNodeSchedulable"
 	eventReasonRemoveFinalizer              = "RemoveFinalizer"
 	eventReasonRemoveNoExecute              = "RemoveNoExecuteTaint"
 	eventReasonRemoveOutOfService           = "RemoveOutOfService"
@@ -66,11 +64,6 @@ const (
 )
 
 var (
-	NodeUnschedulableTaint = &v1.Taint{
-		Key:    "node.kubernetes.io/unschedulable",
-		Effect: v1.TaintEffectNoSchedule,
-	}
-
 	NodeNoExecuteTaint = &v1.Taint{
 		Key:    "medik8s.io/remediation",
 		Value:  "self-node-remediation",
@@ -497,10 +490,6 @@ func (r *SelfNodeRemediationReconciler) prepareReboot(ctx context.Context, node 
 		return ctrl.Result{}, err
 	}
 
-	if !node.Spec.Unschedulable || !utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
-		return r.markNodeAsUnschedulable(node)
-	}
-
 	if err := r.setTimeAssumedRebooted(ctx, node, snr); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -559,22 +548,6 @@ func (r *SelfNodeRemediationReconciler) handleFencingCompletedPhase(node *v1.Nod
 
 func (r *SelfNodeRemediationReconciler) recoverNode(node *v1.Node, snr *v1alpha1.SelfNodeRemediation) (ctrl.Result, error) {
 	r.logger.Info("fencing completed, cleaning up")
-	if node.Spec.Unschedulable {
-		node.Spec.Unschedulable = false
-		if err := r.Client.Update(context.Background(), node); err != nil {
-			if apiErrors.IsConflict(err) {
-				return ctrl.Result{RequeueAfter: time.Second}, nil
-			}
-			r.logger.Error(err, "failed to unmark node as schedulable")
-			return ctrl.Result{}, err
-		}
-		events.NormalEvent(r.Recorder, node, eventReasonMarkSchedulable, "Remediation process - mark healthy remediated node as schedulable")
-	}
-
-	// wait until NoSchedulable taint was removed
-	if utils.TaintExists(node.Spec.Taints, NodeUnschedulableTaint) {
-		return ctrl.Result{RequeueAfter: time.Second}, nil
-	}
 
 	if err := r.removeNoExecuteTaint(node); err != nil {
 		return ctrl.Result{}, err
@@ -738,29 +711,6 @@ func (r *SelfNodeRemediationReconciler) getNodeFromSnr(ctx context.Context, snr 
 		return nil, err
 	}
 	return node, nil
-}
-
-// the unhealthy node might reboot itself and take new workloads
-// since we're going to delete the node eventually, we must make sure the node is deleted only
-// when there's no running workload there. Hence we mark it as unschedulable.
-// markNodeAsUnschedulable sets node.Spec.Unschedulable which triggers node controller to add the taint
-func (r *SelfNodeRemediationReconciler) markNodeAsUnschedulable(node *v1.Node) (ctrl.Result, error) {
-	if node.Spec.Unschedulable {
-		r.logger.Info("waiting for unschedulable taint to appear", "node name", node.Name)
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-	}
-
-	node.Spec.Unschedulable = true
-	r.logger.Info("Marking node as unschedulable", "node name", node.Name)
-	if err := r.Client.Update(context.Background(), node); err != nil {
-		if apiErrors.IsConflict(err) {
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-		}
-		r.logger.Error(err, "failed to mark node as unschedulable")
-		return ctrl.Result{}, err
-	}
-	events.NormalEvent(r.Recorder, node, eventReasonMarkUnschedulable, "Remediation process - unhealthy node marked as unschedulable")
-	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 func (r *SelfNodeRemediationReconciler) updateSnrStatusLastError(snr *v1alpha1.SelfNodeRemediation, err error) error {

--- a/controllers/tests/controller/selfnoderemediation_controller_test.go
+++ b/controllers/tests/controller/selfnoderemediation_controller_test.go
@@ -179,13 +179,7 @@ var _ = Describe("SNR Controller", func() {
 			})
 
 			It("Remediation flow", func() {
-				node := verifyNodeIsUnschedulable()
-
 				verifyEvent("Normal", "RemediationStarted", "Remediation started by SNR manager")
-
-				verifyEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
-
-				addUnschedulableTaint(node)
 
 				verifyTypeConditions(snr, metav1.ConditionTrue, metav1.ConditionUnknown, "RemediationStarted")
 
@@ -211,12 +205,6 @@ var _ = Describe("SNR Controller", func() {
 
 				deleteSNR(snr)
 
-				verifyNodeIsSchedulable()
-
-				removeUnschedulableTaint()
-
-				verifyEvent("Normal", "MarkNodeSchedulable", "Remediation process - mark healthy remediated node as schedulable")
-
 				verifyNoExecuteTaintRemoved()
 
 				verifyEvent("Normal", "RemoveNoExecuteTaint", "Remediation process - remove NoExecute taint from healthy remediated node")
@@ -231,11 +219,7 @@ var _ = Describe("SNR Controller", func() {
 			})
 
 			It("The snr agent attempts to keep deleting node resources during temporary api-server failure", func() {
-				node := verifyNodeIsUnschedulable()
-
 				k8sClient.ShouldSimulatePodDeleteFailure = true
-
-				addUnschedulableTaint(node)
 
 				verifyTypeConditions(snr, metav1.ConditionTrue, metav1.ConditionUnknown, "RemediationStarted")
 
@@ -253,8 +237,6 @@ var _ = Describe("SNR Controller", func() {
 				verifySelfNodeRemediationPodDoesntExist()
 
 				deleteSNR(snr)
-
-				removeUnschedulableTaint()
 
 				verifySNRDoesNotExists(snr)
 
@@ -310,11 +292,6 @@ var _ = Describe("SNR Controller", func() {
 					} else {
 						createSNR(snr, remediationStrategy)
 					}
-
-					node := verifyNodeIsUnschedulable()
-
-					addUnschedulableTaint(node)
-
 					verifyTypeConditions(snr, metav1.ConditionTrue, metav1.ConditionUnknown, "RemediationStarted")
 
 					// The normal NoExecute taint tries to delete pods, however it can't delete pods
@@ -344,10 +321,6 @@ var _ = Describe("SNR Controller", func() {
 
 					deleteSNR(snr)
 
-					verifyNodeIsSchedulable()
-
-					removeUnschedulableTaint()
-
 					verifyNoExecuteTaintRemoved()
 
 					verifySNRDoesNotExists(snr)
@@ -362,10 +335,6 @@ var _ = Describe("SNR Controller", func() {
 				})
 
 				createSNR(snr, remediationStrategy)
-
-				node := verifyNodeIsUnschedulable()
-				addUnschedulableTaint(node)
-
 				verifyTypeConditions(snr, metav1.ConditionTrue, metav1.ConditionUnknown, "RemediationStarted")
 
 				// Create terminating pod but DON'T delete it - this simulates workloads stuck in terminating state
@@ -406,8 +375,6 @@ var _ = Describe("SNR Controller", func() {
 
 				// Clean up: manually delete the terminating pod and SNR to complete the test
 				deleteTerminatingPod()
-				verifyNodeIsSchedulable()
-				removeUnschedulableTaint()
 				verifyNoExecuteTaintRemoved()
 				verifySNRDoesNotExists(snr)
 			})
@@ -462,10 +429,6 @@ var _ = Describe("SNR Controller", func() {
 						})
 					})
 
-					It("Node is found and set with Unschedulable taint", func() {
-						time.Sleep(time.Second)
-						verifyEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
-					})
 				})
 
 				When("the wrong  NodeRef is set in the machine statusThe", func() {
@@ -481,7 +444,6 @@ var _ = Describe("SNR Controller", func() {
 					When("NHC isn't set as owner in the remediation", func() {
 						It("Node is not found", func() {
 							time.Sleep(time.Second)
-							verifyNoEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
 							verifyTypeConditions(snr, metav1.ConditionFalse, metav1.ConditionFalse, "RemediationSkippedNodeNotFound")
 							verifyEvent("Warning", "RemediationCannotStart", "Could not get remediation target Node")
 						})
@@ -489,11 +451,6 @@ var _ = Describe("SNR Controller", func() {
 					When("NHC is set as owner in the remediation", func() {
 						BeforeEach(func() {
 							snr.OwnerReferences = append(snr.OwnerReferences, metav1.OwnerReference{Name: "nhc", Kind: "NodeHealthCheck", APIVersion: "remediation.medik8s.io/v1alpha1", UID: "12345"})
-						})
-
-						It("Node is found and set with Unschedulable taint", func() {
-							time.Sleep(time.Second)
-							verifyEvent("Normal", "MarkUnschedulable", "Remediation process - unhealthy node marked as unschedulable")
 						})
 					})
 				})
@@ -589,15 +546,6 @@ func verifySelfNodeRemediationPodDoesntExist() {
 	}, shared.CalculatedRebootDuration+10*time.Second, 250*time.Millisecond).Should(BeTrue())
 }
 
-func verifyNodeIsSchedulable() {
-	By("Verify that node is not marked as unschedulable")
-	node := &v1.Node{}
-	Eventually(func() (bool, error) {
-		err := k8sClient.Client.Get(context.TODO(), unhealthyNodeNamespacedName, node)
-		return node.Spec.Unschedulable, err
-	}, 95*time.Second, 250*time.Millisecond).Should(BeFalse())
-}
-
 func verifyWatchdogTriggered() {
 	EventuallyWithOffset(1, func(g Gomega) {
 		g.Expect(dummyDog.Status()).To(Equal(watchdog.Triggered))
@@ -675,31 +623,6 @@ func verifySNRDoesNotExists(snr *v1alpha1.SelfNodeRemediation) {
 		err := k8sClient.Get(context.Background(), snrNamespacedName, snr)
 		return apierrors.IsNotFound(err)
 	}, 5*time.Second, 250*time.Millisecond).Should(BeTrue())
-}
-
-func addUnschedulableTaint(node *v1.Node) {
-	By("Add unschedulable taint to node to simulate node controller")
-	node.Spec.Taints = append(node.Spec.Taints, *controllers.NodeUnschedulableTaint)
-	ExpectWithOffset(1, k8sClient.Client.Update(context.TODO(), node)).To(Succeed())
-}
-
-func removeUnschedulableTaint() {
-	By("Removing unschedulable taint to node to simulate node controller")
-	updateNodeFund := func(node *v1.Node) {
-		taints, _ := utils.DeleteTaint(node.Spec.Taints, controllers.NodeUnschedulableTaint)
-		node.Spec.Taints = taints
-	}
-	eventuallyUpdateNode(updateNodeFund, false)
-}
-
-func verifyNodeIsUnschedulable() *v1.Node {
-	By("Verify that node was marked as unschedulable")
-	node := &v1.Node{}
-	EventuallyWithOffset(1, func() (bool, error) {
-		err := k8sClient.Client.Get(context.TODO(), unhealthyNodeNamespacedName, node)
-		return node.Spec.Unschedulable, err
-	}, 5*time.Second, 250*time.Millisecond).Should(BeTrue(), "node should be marked as unschedulable")
-	return node
 }
 
 func verifySelfNodeRemediationPodExist() {


### PR DESCRIPTION


<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
This is a leftover from early k8s days when taints and tolerations didn’t exist yet. It only still exists because removing it would be a node API change. The scheduler only looks at taints, and more info is at https://github.com/kubernetes/kubernetes/issues/69010
#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- Remove the logic for marking the node as `unscheduleable` by updating the spec
- Update Unit-tests accordingly and avoid testing the node spec.unscheduleable value

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

[RHWA-571](https://issues.redhat.com//browse/RHWA-571)
#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified node remediation workflow by removing unschedulable state handling, now relying exclusively on NoExecute and OutOfService taint mechanisms for node remediation and recovery operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->