### PR TITLE
Parameterize inclusion of "remediation.medik8s.io/include-in-remediation" label for nodeAffinity

### DIFF
--- a/api/v1alpha1/selfnoderemediationconfig_types.go
+++ b/api/v1alpha1/selfnoderemediationconfig_types.go
@@ -25,10 +25,11 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 const (
-	ConfigCRName                   = "self-node-remediation-config"
-	defaultWatchdogPath            = "/dev/watchdog"
-	defaultIsSoftwareRebootEnabled = true
-	defaultMinPeersForRemediation  = 1
+	ConfigCRName                           = "self-node-remediation-config"
+	defaultWatchdogPath                    = "/dev/watchdog"
+	defaultIsSoftwareRebootEnabled         = true
+	defaultEnableIncludeInRemediationLabel = false
+	defaultMinPeersForRemediation          = 1
 )
 
 // SelfNodeRemediationConfigSpec defines the desired state of SelfNodeRemediationConfig
@@ -113,6 +114,12 @@ type SelfNodeRemediationConfigSpec struct {
 	// +optional
 	IsSoftwareRebootEnabled bool `json:"isSoftwareRebootEnabled,omitempty"`
 
+	// EnableIncludeInRemediationLabel indicates whether we will include remediation.medik8s.io/include-in-remediation
+	// label in nodeAffinity configuration as a required for the pod to be deployed on specific node.
+	// +kubebuilder:default=false
+	// +optional
+	EnableIncludeInRemediationLabel bool `json:"enableIncludeInRemediationLabel,omitempty"`
+
 	// EndpointHealthCheckUrl is an url that self node remediation agents which run on control-plane node will try to access when they can't contact their peers.
 	// This is a part of self diagnostics which will decide whether the node should be remediated or not.
 	// It will be ignored when empty (which is the default).
@@ -178,8 +185,9 @@ func NewDefaultSelfNodeRemediationConfig() SelfNodeRemediationConfig {
 			Name: ConfigCRName,
 		},
 		Spec: SelfNodeRemediationConfigSpec{
-			WatchdogFilePath:        defaultWatchdogPath,
-			IsSoftwareRebootEnabled: defaultIsSoftwareRebootEnabled,
+			WatchdogFilePath:                defaultWatchdogPath,
+			IsSoftwareRebootEnabled:         defaultIsSoftwareRebootEnabled,
+			EnableIncludeInRemediationLabel: defaultEnableIncludeInRemediationLabel,
 		},
 	}
 }

--- a/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/bundle/manifests/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -121,6 +121,12 @@ spec:
                   if the watchdog device can not be used or will use watchdog only,
                   without a fallback to software reboot.
                 type: boolean
+              enableIncludeInRemediationLabel:
+                default: false
+                description: |-
+                  Enable inclusion of "remediation.medik8s.io/include-in-remediation" label in nodeAffinity configuration
+                  for DaemonSet as a required for the pod to be deployed on specific node.
+                type: boolean
               maxApiErrorThreshold:
                 default: 3
                 description: After this threshold, the node will start contacting

--- a/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
+++ b/config/crd/bases/self-node-remediation.medik8s.io_selfnoderemediationconfigs.yaml
@@ -119,6 +119,12 @@ spec:
                   if the watchdog device can not be used or will use watchdog only,
                   without a fallback to software reboot.
                 type: boolean
+              enableIncludeInRemediationLabel:
+                default: false
+                description: |-
+                  Enable inclusion of "remediation.medik8s.io/include-in-remediation" label in nodeAffinity configuration
+                  for DaemonSet as a required for the pod to be deployed on specific node.
+                type: boolean
               maxApiErrorThreshold:
                 default: 3
                 description: After this threshold, the node will start contacting

--- a/controllers/selfnoderemediationconfig_controller.go
+++ b/controllers/selfnoderemediationconfig_controller.go
@@ -158,6 +158,7 @@ func (r *SelfNodeRemediationConfigReconciler) syncConfigDaemonSet(ctx context.Co
 	data.Data["MinPeersForRemediation"] = snrConfig.Spec.MinPeersForRemediation
 	data.Data["HostPort"] = snrConfig.Spec.HostPort
 	data.Data["IsSoftwareRebootEnabled"] = fmt.Sprintf("\"%t\"", snrConfig.Spec.IsSoftwareRebootEnabled)
+	data.Data["EnableIncludeInRemediationLabel"] = snrConfig.Spec.EnableIncludeInRemediationLabel
 
 	objs, err := render.Dir(r.InstallFileFolder, &data)
 	if err != nil {

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -35,6 +35,12 @@ spec:
                   operator: NotIn
                   values:
                   - "true"
+                {{ if .EnableIncludeInRemediationLabel }}
+                - key: remediation.medik8s.io/include-in-remediation
+                  operator: In
+                  values:
+                    - "true"
+                {{ end }}
       hostPID: true
       containers:
       - args:


### PR DESCRIPTION
…ion" label in DaemonSet nodeAffinity configuration.

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
This will give ability to conditionally include labels in nodeAffinity configuration for DaemonSet.

#### Changes made
Include enableIncludeInRemediationLabel configuration option, with default value `false` to be compatible with current default configuration.


#### Which issue(s) this PR fixes

Fixes #285 


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional configuration setting to enable the inclusion of the remediation label in DaemonSet node affinity scheduling rules. When enabled, this option provides more granular control over which nodes are eligible for remediation operations. The feature defaults to disabled to maintain full backward compatibility with existing system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->