### PR TITLE
Add optional checkout_ref input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ on:
      ocp_version:
        description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
        required: false
+     checkout_ref:
+       description: 'Override the ref to checkout (defaults to the triggering ref)'
+       required: false
+       default: ''
 
 permissions:
   contents: write
@@ -42,6 +46,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
           fetch-depth: 0
 
       - name: Set up Go


### PR DESCRIPTION
## Why we need this PR

When triggering the release workflow manually via `workflow_dispatch`, there is no way to override which git ref is checked out. This makes it difficult to run the release workflow against a specific branch or tag other than the default.

## Changes made

- Added an optional `checkout_ref` input to the `workflow_dispatch` trigger in `release.yml`
- Updated the `actions/checkout` step to use `ref: ${{ inputs.checkout_ref || github.ref }}`, falling back to the triggering ref when not specified

## Which issue(s) this PR fixes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)