### PR TITLE
Detect host architecture for GOARCH in build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ ifeq (,$(wildcard $(OPERATOR_SDK)))
 	set -e ;\
 	rm -rf $(OPERATOR_SDK_BIN_FOLDER) ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=linux && ARCH=amd64 && \
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
@@ -434,7 +434,7 @@ ifeq (,$(wildcard $(OPM)))
 	set -e ;\
 	rm -rf $(OPM_BIN_FOLDER) ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=linux && ARCH=amd64 && \
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -28,4 +28,14 @@ echo "cgo: ${CGO_ENABLED}"
 # export in case it was set
 export GOEXPERIMENT="${GOEXPERIMENT}"
 
-GOOS=linux GOARCH=amd64 go build -o bin/manager main.go
+# Detect target architecture
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64)   GOARCH="amd64"   ;;
+  aarch64|arm64) GOARCH="arm64" ;;
+  s390x)    GOARCH="s390x"   ;;
+  ppc64le)  GOARCH="ppc64le" ;;
+  *)        echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+GOOS=linux GOARCH=${GOARCH} go build -o bin/manager main.go

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -28,4 +28,6 @@ echo "cgo: ${CGO_ENABLED}"
 # export in case it was set
 export GOEXPERIMENT="${GOEXPERIMENT}"
 
-GOOS=linux GOARCH=amd64 go build -o bin/manager cmd/main.go
+# detect target arch from Go toolchain, default to amd64
+GOARCH=$(go env GOARCH)
+GOOS=linux GOARCH=${GOARCH:-amd64} go build -o bin/manager cmd/main.go


### PR DESCRIPTION
#### Why we need this PR

`hack/build.sh` hardcodes `GOARCH=amd64`, which prevents building the operator binary on non-x86_64 hosts (e.g. arm64, s390x, ppc64le). Anyone building on those platforms must manually override GOARCH.

Similarly, the Makefile `operator-sdk` and `opm` download targets hardcode `OS=linux && ARCH=amd64`, which downloads amd64 binaries regardless of the host architecture. This causes `Exec format error` when CI runs on a non-amd64 node (observed on NHC CI with OCP 4.20 arm64 nodes — same latent bug exists here).

#### Changes made

- `hack/build.sh`: Detect host architecture at build time using `go env GOARCH`, fall back to `amd64` if empty
- `Makefile`: Use `$(shell go env GOOS)` and `$(shell go env GOARCH)` for `operator-sdk` and `opm` downloads, matching the pattern already used by MDR, FAR, and NMO
- No behavior change on x86_64 hosts (`go env GOARCH` returns `amd64`, same as before)

#### Which issue(s) this PR fixes

Related to [RHWA-514](https://redhat.atlassian.net/browse/RHWA-514). Enables the Go binary build and tool downloads to work on non-amd64 hosts.

#### Test plan

- Existing CI runs on amd64 and produces identical behavior (no regression)
- `go env GOARCH` returns the correct architecture on all supported platforms
- `operator-sdk` and `opm` binaries match the host architecture after download