### PR TITLE
Switch runtime base image to UBI Minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,13 @@ COPY install/ install/
 # Build
 RUN ./hack/build.sh
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
+
+# nsenter is required by the self-node-remediation agent
+RUN microdnf install -y util-linux && microdnf clean all -y
+
 COPY --from=builder /workspace/install/ install/
 COPY --from=builder /workspace/bin/manager .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,9 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 
-# nsenter is required by the self-node-remediation agent
-RUN microdnf install -y util-linux iproute && microdnf clean all -y
+# util-linux: nsenter is required by the self-node-remediation agent
+# iproute: ip command is needed by e2e tests to simulate API server disconnection
+RUN microdnf install -y --setopt=install_weak_deps=0 util-linux iproute && microdnf clean all -y
 
 COPY --from=builder /workspace/install/ install/
 COPY --from=builder /workspace/bin/manager .

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 
 # nsenter is required by the self-node-remediation agent
-RUN microdnf install -y util-linux && microdnf clean all -y
+RUN microdnf install -y util-linux iproute && microdnf clean all -y
 
 COPY --from=builder /workspace/install/ install/
 COPY --from=builder /workspace/bin/manager .


### PR DESCRIPTION
## Summary

- Switch runtime base image from `ubi9/ubi` to `ubi9/ubi-minimal`
- Install `util-linux` via `microdnf` to provide `nsenter` (required by the SNR agent)
- Install `iproute` via `microdnf` for e2e tests that simulate API server disconnection (`ip route add blackhole` inside the agent pod). This is a test-only dependency — the production agent does not use it.

## Motivation

UBI Minimal reduces image size and CVE noise. `ubi9/ubi` includes many packages
that SNR does not need. The only runtime dependency from the base image is `nsenter`,
which is provided by `util-linux` and can be installed via `microdnf`.

## Note on upstream vs downstream differences

The downstream Containerfile (Konflux) does not include `iproute` because downstream
e2e tests do not run against the downstream image. It also copies `nsenter` directly
from the builder stage instead of using `microdnf`, since the downstream build runs
in hermetic mode (`hermetic: true`) which blocks network access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched the runtime image to a more minimal base to reduce image size and streamline deployments.
  * Added essential runtime utilities (including networking/system tooling so nsenter is available) to ensure required tools are present in the final image.
  * Cleaned package metadata to keep the image lean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/medik8s/self-node-remediation/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->