### PR TITLE
fix: remediate CP node when peer control planes consider it unhealthy

### DIFF
--- a/internal/apicheck/check.go
+++ b/internal/apicheck/check.go
@@ -125,10 +125,9 @@ func (c *ApiConnectivityCheck) isConsideredHealthy() bool {
 	isWorkerNode := c.controlPlaneManager == nil || !c.controlPlaneManager.IsControlPlane()
 	if isWorkerNode {
 		return workerPeersResponse.IsHealthy
-	} else {
-		return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, c.canOtherControlPlanesBeReached())
 	}
-
+	canBeReached, cpUnhealthy := c.getControlPlanePeersStatus()
+	return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, canBeReached, cpUnhealthy)
 }
 
 func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {
@@ -232,19 +231,24 @@ func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {
 
 }
 
-func (c *ApiConnectivityCheck) canOtherControlPlanesBeReached() bool {
+// getControlPlanePeersStatus contacts peer control plane nodes and returns whether they can be reached
+// and whether they consider this node unhealthy (i.e. a SNR CR exists for it).
+func (c *ApiConnectivityCheck) getControlPlanePeersStatus() (canBeReached bool, consideredUnhealthy bool) {
 	peersToAsk := c.config.Peers.GetPeersAddresses(peers.ControlPlane)
 	numOfControlPlanePeers := len(peersToAsk)
 	if numOfControlPlanePeers == 0 {
 		c.config.Log.Info("Peers list is empty and / or couldn't be retrieved from server, other control planes can't be reached")
-		return false
+		return false, false
 	}
 
 	chosenPeersIPs := c.popPeerIPs(&peersToAsk, numOfControlPlanePeers)
 	healthyResponses, unhealthyResponses, apiErrorsResponses, _ := c.getHealthStatusFromPeers(chosenPeersIPs)
 
+	c.config.Log.Info("Control plane peers status", "healthyResponses", healthyResponses,
+		"unhealthyResponses", unhealthyResponses, "apiErrorsResponses", apiErrorsResponses)
+
 	// Any response is an indication of communication with a peer
-	return (healthyResponses + unhealthyResponses + apiErrorsResponses) > 0
+	return (healthyResponses + unhealthyResponses + apiErrorsResponses) > 0, unhealthyResponses > 0
 }
 
 func (c *ApiConnectivityCheck) popPeerIPs(peersIPs *[]corev1.PodIP, count int) []corev1.PodIP {

--- a/internal/apicheck/check.go
+++ b/internal/apicheck/check.go
@@ -127,7 +127,12 @@ func (c *ApiConnectivityCheck) isConsideredHealthy() bool {
 		return workerPeersResponse.IsHealthy
 	}
 	canBeReached, cpUnhealthy := c.getControlPlanePeersStatus()
-	return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, canBeReached, cpUnhealthy)
+	if cpUnhealthy {
+		c.config.Log.Info("Peer control plane nodes reported this node as unhealthy, triggering remediation")
+		return false
+	}
+
+	return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, canBeReached)
 }
 
 func (c *ApiConnectivityCheck) getWorkerPeersResponse() peers.Response {

--- a/internal/controller/tests/controller/selfnoderemediation_controller_test.go
+++ b/internal/controller/tests/controller/selfnoderemediation_controller_test.go
@@ -525,7 +525,6 @@ var _ = Describe("SNR Controller", func() {
 				patch := client.MergeFrom(node.DeepCopy())
 				node.Labels[commonlabels.ControlPlaneRole] = ""
 				Expect(k8sClient.Client.Patch(context.Background(), node, patch)).To(Succeed())
-				nodeName := nodeName
 				DeferCleanup(func() {
 					n := &corev1.Node{}
 					Expect(k8sClient.Client.Get(context.Background(), client.ObjectKey{Name: nodeName}, n)).To(Succeed())
@@ -606,8 +605,11 @@ var _ = Describe("SNR Controller", func() {
 			cpManager := controlplane.NewManager(shared.UnhealthyNodeName, k8sClient.Client)
 			Expect(cpManager.Start(context.Background())).To(Succeed())
 
-			// 8. Give Peers time to run its first update and populate controlPlanePeersAddresses.
-			time.Sleep(2 * time.Second)
+			// 8. Wait until Peers has run its first update and populated controlPlanePeersAddresses.
+			Eventually(func() bool {
+				return len(cpPeers.GetPeersAddresses(peerspkg.ControlPlane)) > 0
+			}, 10*time.Second, 250*time.Millisecond).Should(BeTrue(),
+				"cpPeers should have at least one CP peer address populated")
 
 			// 9. Start a dedicated watchdog for the CP apiCheck and wait until it is Armed.
 			//    Without calling Start(), GetTimeout() returns 0 and Reboot() skips Stop().

--- a/internal/controller/tests/controller/selfnoderemediation_controller_test.go
+++ b/internal/controller/tests/controller/selfnoderemediation_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	commonlabels "github.com/medik8s/common/pkg/labels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -16,14 +17,21 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
 	"github.com/medik8s/self-node-remediation/api/v1alpha1"
+	"github.com/medik8s/self-node-remediation/internal/apicheck"
+	"github.com/medik8s/self-node-remediation/internal/certificates"
 	"github.com/medik8s/self-node-remediation/internal/controller"
 	"github.com/medik8s/self-node-remediation/internal/controller/tests/shared"
+	"github.com/medik8s/self-node-remediation/internal/controlplane"
+	"github.com/medik8s/self-node-remediation/internal/peerhealth"
+	peerspkg "github.com/medik8s/self-node-remediation/internal/peers"
+	"github.com/medik8s/self-node-remediation/internal/reboot"
 	"github.com/medik8s/self-node-remediation/internal/utils"
 	"github.com/medik8s/self-node-remediation/internal/watchdog"
 )
@@ -498,6 +506,152 @@ var _ = Describe("SNR Controller", func() {
 		})
 		It("verify remediation updated snr status", func() {
 			shared.VerifySNRStatusExist(k8sClient, snr, "Disabled", metav1.ConditionTrue)
+		})
+	})
+
+	// Regression test for https://github.com/medik8s/self-node-remediation/issues/251:
+	// A control-plane node whose worker-peer path yields no result (isolated from workers)
+	// must still remediate when peer CP nodes have a SNR CR for it (consider it unhealthy).
+	Context("Control plane node - API server down - CP peer reports it unhealthy", func() {
+		const cpPeerHealthPort = 9001
+
+		var cpDummyDog watchdog.FakeWatchdog
+
+		BeforeEach(func() {
+			// 1. Label both nodes as control-plane so the Peers selector works correctly.
+			for _, nodeName := range []string{shared.UnhealthyNodeName, shared.PeerNodeName} {
+				node := &corev1.Node{}
+				Expect(k8sClient.Client.Get(context.Background(), client.ObjectKey{Name: nodeName}, node)).To(Succeed())
+				patch := client.MergeFrom(node.DeepCopy())
+				node.Labels[commonlabels.ControlPlaneRole] = ""
+				Expect(k8sClient.Client.Patch(context.Background(), node, patch)).To(Succeed())
+				nodeName := nodeName
+				DeferCleanup(func() {
+					n := &corev1.Node{}
+					Expect(k8sClient.Client.Get(context.Background(), client.ObjectKey{Name: nodeName}, n)).To(Succeed())
+					p := client.MergeFrom(n.DeepCopy())
+					delete(n.Labels, commonlabels.ControlPlaneRole)
+					Expect(k8sClient.Client.Patch(context.Background(), n, p)).To(Succeed())
+				})
+			}
+
+			// 2. Generate TLS certs shared between the peerhealth server and the apiCheck client.
+			caPem, certPem, keyPem, err := certificates.CreateCerts()
+			Expect(err).ToNot(HaveOccurred())
+			certReader := &certificates.MemoryCertStorage{
+				CaPem:   caPem,
+				CertPem: certPem,
+				KeyPem:  keyPem,
+			}
+
+			// 3. Start a real peerhealth gRPC server on localhost representing the peer CP node.
+			//    It uses the direct API reader (not the failure-simulation wrapper) so it can
+			//    still list SNR CRs even when ShouldSimulateFailure is true.
+			phServer, err := peerhealth.NewServer(
+				k8sClient.Client,
+				k8sClient.Reader,
+				ctrl.Log.WithName("cp-peer-health-server"),
+				cpPeerHealthPort,
+				certReader,
+				5*time.Second,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			serverCtx, cancelServer := context.WithCancel(context.Background())
+			go func() { _ = phServer.Start(serverCtx) }()
+			DeferCleanup(cancelServer)
+
+			// 4. Create a fake SNR-agent pod on the peer node with podIP=127.0.0.1 so that
+			//    GetPeersAddresses(ControlPlane) resolves to the test gRPC server above.
+			cpPeerPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cp-peer-snr-pod",
+					Namespace: shared.Namespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":      "self-node-remediation",
+						"app.kubernetes.io/component": "agent",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:   shared.PeerNodeName,
+					Containers: []corev1.Container{{Name: "snr", Image: "dummy"}},
+				},
+			}
+			Expect(k8sClient.Client.Create(context.Background(), cpPeerPod)).To(Succeed())
+			cpPeerPod.Status.PodIPs = []corev1.PodIP{{IP: "127.0.0.1"}}
+			Expect(k8sClient.Client.Status().Update(context.Background(), cpPeerPod)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Client.Delete(context.Background(), cpPeerPod)
+			})
+
+			// 5. Create the SNR CR for the unhealthy CP node so the peerhealth server returns Unhealthy.
+			createSNR(snr, v1alpha1.ResourceDeletionRemediationStrategy)
+			DeferCleanup(func() { deleteSNR(snr) })
+
+			// 6. Build a dedicated Peers instance for the CP apiCheck.
+			//    It must be started AFTER the CP labels are applied so that
+			//    controlPlanePeerSelector is built correctly.
+			cpPeers := peerspkg.New(
+				shared.UnhealthyNodeName,
+				shared.ApiCheckInterval, // short interval so the first update happens quickly
+				k8sClient.Reader,
+				ctrl.Log.WithName("cp-peers"),
+				5*time.Second,
+			)
+			cpPeersCtx, cancelCpPeers := context.WithCancel(context.Background())
+			go func() { _ = cpPeers.Start(cpPeersCtx) }()
+			DeferCleanup(cancelCpPeers)
+
+			// 7. Initialise the controlplane.Manager for the unhealthy CP node and call Start
+			//    while the API is still reachable.
+			cpManager := controlplane.NewManager(shared.UnhealthyNodeName, k8sClient.Client)
+			Expect(cpManager.Start(context.Background())).To(Succeed())
+
+			// 8. Give Peers time to run its first update and populate controlPlanePeersAddresses.
+			time.Sleep(2 * time.Second)
+
+			// 9. Start a dedicated watchdog for the CP apiCheck and wait until it is Armed.
+			//    Without calling Start(), GetTimeout() returns 0 and Reboot() skips Stop().
+			cpDummyDog = watchdog.NewFake(true)
+			cpDogCtx, cancelCpDog := context.WithCancel(context.Background())
+			go func() { _ = cpDummyDog.Start(cpDogCtx) }()
+			DeferCleanup(cancelCpDog)
+			Eventually(func() bool {
+				return cpDummyDog.Status() == watchdog.Armed
+			}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), "cpDummyDog should reach Armed state")
+
+			// 10. Build and start the CP apiCheck.
+			//     Use an unreachable host so the REST /readyz check always fails immediately.
+			//     ShouldSimulateFailure only intercepts List() calls and has no effect on
+			//     the raw REST request, so a fake host is the reliable way to force failure.
+			fakeCfg := *cfg
+			fakeCfg.Host = "https://127.0.0.1:1"
+			cpRebooter := reboot.NewWatchdogRebooter(cpDummyDog, ctrl.Log.WithName("cp-rebooter"))
+			cpApiCheckCfg := &apicheck.ApiConnectivityCheckConfig{
+				Log:                    ctrl.Log.WithName("cp-api-check"),
+				MyNodeName:             shared.UnhealthyNodeName,
+				CheckInterval:          shared.ApiCheckInterval,
+				MaxErrorsThreshold:     shared.MaxErrorThreshold,
+				Peers:                  cpPeers,
+				Rebooter:               cpRebooter,
+				Cfg:                    &fakeCfg,
+				MinPeersForRemediation: 0, // forces UnHealthyBecauseNodeIsIsolated path (the bug path from issue #251)
+				CertReader:             certReader,
+				PeerHealthPort:         cpPeerHealthPort,
+				PeerDialTimeout:        5 * time.Second,
+				PeerRequestTimeout:     7 * time.Second,
+				ApiServerTimeout:       5 * time.Second,
+			}
+			cpApiCheck := apicheck.New(cpApiCheckCfg, cpManager)
+			cpCheckCtx, cancelCpCheck := context.WithCancel(context.Background())
+			go func() { _ = cpApiCheck.Start(cpCheckCtx) }()
+			DeferCleanup(cancelCpCheck)
+		})
+
+		It("should trigger the watchdog when CP peers report this node unhealthy (fix for issue #251)", func() {
+			EventuallyWithOffset(1, func(g Gomega) {
+				g.Expect(cpDummyDog.Status()).To(Equal(watchdog.Triggered))
+			}, 30*time.Second, 1*time.Second).Should(Succeed(),
+				"watchdog should be triggered: CP peers reported node unhealthy but watchdog was not triggered")
 		})
 	})
 })

--- a/internal/controller/tests/controller/suite_test.go
+++ b/internal/controller/tests/controller/suite_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,6 +64,7 @@ var (
 	fakeRecorder               *record.FakeRecorder
 	snrConfig                  *selfnoderemediationv1alpha1.SelfNodeRemediationConfig
 	apiConnectivityCheckConfig *apicheck.ApiConnectivityCheckConfig
+	cfg                        *rest.Config
 )
 
 var unhealthyNodeNamespacedName = client.ObjectKey{
@@ -97,7 +99,8 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/internal/controlplane/manager.go
+++ b/internal/controlplane/manager.go
@@ -57,11 +57,7 @@ func (manager *Manager) IsControlPlane() bool {
 	return manager.nodeRole == peers.ControlPlane
 }
 
-func (manager *Manager) IsControlPlaneHealthy(workerPeerResponse peers.Response, canOtherControlPlanesBeReached bool, cpUnhealthy bool) bool {
-	if cpUnhealthy {
-		manager.log.Info("Peer control plane nodes reported this node as unhealthy, triggering remediation")
-		return false
-	}
+func (manager *Manager) IsControlPlaneHealthy(workerPeerResponse peers.Response, canOtherControlPlanesBeReached bool) bool {
 	switch workerPeerResponse.Reason {
 	//reported unhealthy by worker peers
 	case peers.UnHealthyBecausePeersResponse:

--- a/internal/controlplane/manager.go
+++ b/internal/controlplane/manager.go
@@ -57,7 +57,11 @@ func (manager *Manager) IsControlPlane() bool {
 	return manager.nodeRole == peers.ControlPlane
 }
 
-func (manager *Manager) IsControlPlaneHealthy(workerPeerResponse peers.Response, canOtherControlPlanesBeReached bool) bool {
+func (manager *Manager) IsControlPlaneHealthy(workerPeerResponse peers.Response, canOtherControlPlanesBeReached bool, cpUnhealthy bool) bool {
+	if cpUnhealthy {
+		manager.log.Info("Peer control plane nodes reported this node as unhealthy, triggering remediation")
+		return false
+	}
 	switch workerPeerResponse.Reason {
 	//reported unhealthy by worker peers
 	case peers.UnHealthyBecausePeersResponse:


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->
This PR leans on the groundwork and analysis made by   @mark-dell-usa in https://github.com/medik8s/self-node-remediation/pull/255 , but is using a different solution approach. 

#### Why we need this PR
When a control-plane node loses API server access and cannot reach worker peers (UnHealthyBecauseNodeIsIsolated), SNR checks whether other CP nodes are reachable before deciding to reboot. The reachability check (canOtherControlPlanesBeReached) collapsed all peer responses — including explicit "unhealthy" verdicts — into a single boolean. A peer CP responding "this node is unhealthy" was treated identically to "I'm healthy, network is fine", preventing remediation even when every peer CP had a SNR CR for the broken node.

#### Changes made
Changes made

- internal/apicheck/check.go: Renamed canOtherControlPlanesBeReached() → getControlPlanePeersStatus(), which now returns (canBeReached bool, cpUnhealthy bool). The second value is unhealthyResponses > 0, preserving the peer CPs' health verdict instead of discarding it.
- internal/controlplane/manager.go: IsControlPlaneHealthy gains a third parameter cpUnhealthy bool and short-circuits to false (remediate) at the top of the function, before the worker-response switch, when peer CPs explicitly report this node as unhealthy.
- internal/controller/tests/controller/: unit test that cover this use case.


#### Which issue(s) this PR fixes
[RHWA-384](https://redhat.atlassian.net/browse/RHWA-384)


#### Test plan
Added regression test coverage validating remediation/watchdog behavior for control-plane node scenarios and updated test-suite setup to support it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved control-plane node remediation logic to correctly handle scenarios where control-plane peers report a node as unhealthy.

* **Tests**
  * Added regression test coverage for control-plane node health check and remediation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->