### PR TITLE
Update runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   push_to_registry:
     name: Build and push unversioned images to quay.io/medik8s
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -11,7 +11,7 @@ on: # on events
 jobs:
   build:
     name: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   push_to_registry:
     if: ${{ inputs.operation == 'build_and_push_images' }}
     name: Build and push versioned images to quay.io/medik8s
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       VERSION: ${{ inputs.version }}
       PREVIOUS_VERSION: ${{ inputs.previous_version }}


### PR DESCRIPTION
#### Why we need this PR

Update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04. ubuntu-24.04 has been the `ubuntu-latest` default since January 2025.

#### Changes made

- Updated runner image from `ubuntu-22.04` to `ubuntu-24.04` across all workflows

#### Which issue(s) this PR fixes

[RHWA-853](https://issues.redhat.com/browse/RHWA-853)

#### Test plan

- Pre-submit CI passes with the updated runner image