### PR TITLE
Set readOnlyRootFilesystem on DaemonSet agent container

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -449,15 +449,28 @@ func ensureSnrRunning(nodes *v1.NodeList) {
 			defer wg.Done()
 			pod := findSnrPod(node)
 			utils.WaitForPodReady(k8sClient, pod)
-			verifyNoHostPort(pod)
+			verifyPodSecurity(pod)
 		}()
 	}
 	wg.Wait()
 }
 
-func verifyNoHostPort(pod *v1.Pod) {
+func verifyPodSecurity(pod *v1.Pod) {
 	ExpectWithOffset(1, pod.Spec.Containers).ToNot(BeEmpty())
-	for _, port := range pod.Spec.Containers[0].Ports {
+	container := pod.Spec.Containers[0]
+
+	for _, port := range container.Ports {
 		ExpectWithOffset(1, port.HostPort).To(BeZero(), fmt.Sprintf("port %q should not have hostPort set", port.Name))
 	}
+
+	ExpectWithOffset(1, container.SecurityContext).ToNot(BeNil(), "agent container should have a securityContext")
+	ExpectWithOffset(1, container.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil(), "readOnlyRootFilesystem should be set")
+	ExpectWithOffset(1, *container.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(), "readOnlyRootFilesystem should be true")
+
+	ExpectWithOffset(1, pod.Spec.SecurityContext).ToNot(BeNil(), "pod should have a securityContext")
+	ExpectWithOffset(1, pod.Spec.SecurityContext.RunAsUser).ToNot(BeNil(), "runAsUser should be set")
+	ExpectWithOffset(1, *pod.Spec.SecurityContext.RunAsUser).To(Equal(int64(0)), "pod should run as root (uid 0)")
+
+	ExpectWithOffset(1, pod.Spec.ServiceAccountName).ToNot(BeEmpty())
+	ExpectWithOffset(1, pod.Spec.ServiceAccountName).ToNot(Equal("default"), "should not use the default service account")
 }

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -81,6 +81,7 @@ spec:
             mountPath: /dev
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         name: manager
         ports:
         - containerPort: {{.HostPort}}

--- a/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
@@ -50,13 +50,14 @@ var _ = Describe("SNR Config Test", func() {
 		}, timeToWaitForDSToCreate, 250*time.Millisecond).Should(Succeed())
 
 		Expect(k8sClient.Delete(context.TODO(), tmpConfig)).To(Succeed())
-		Expect(k8sClient.Delete(context.TODO(), tmpDs)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(config), &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{})
+			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 
-		//verify delete is done
+		Expect(k8sClient.Delete(context.TODO(), tmpDs)).To(Succeed())
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(context.Background(), dsKey, &appsv1.DaemonSet{})
-			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
-			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(config), &selfnoderemediationv1alpha1.SelfNodeRemediationConfig{})
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		}, 10*time.Second, 250*time.Millisecond).Should(Succeed())
 	})
@@ -117,6 +118,10 @@ var _ = Describe("SNR Config Test", func() {
 			port := container.Ports[0]
 			Expect(port.ContainerPort).To(BeEquivalentTo(30111))
 			Expect(port.HostPort).To(BeZero())
+
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(container.SecurityContext.Privileged).To(Equal(pointer.Bool(true)))
+			Expect(container.SecurityContext.ReadOnlyRootFilesystem).To(Equal(pointer.Bool(true)))
 		})
 		When("Configuration has customized tolerations", func() {
 			var expectedToleration corev1.Toleration


### PR DESCRIPTION
## Why we need this PR

The SNR DaemonSet agent container should have `readOnlyRootFilesystem: true` set in its securityContext. The agent performs no writes to its container filesystem, so all I/O goes through hostPath mounts, nsenter, or the Kubernetes API — so this is a safe hardening measure.

## Changes made

- Added `readOnlyRootFilesystem: true` to the container-level securityContext in
  `install/self-node-remediation-deamonset.yaml`

## Which issue(s) this PR fixes

N/A

## Test plan

- [x] Verified the agent has no container-local filesystem writes
- [ ] CI passes (unit + e2e)
- [ ] DaemonSet pods start and operate normally with the new setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Security**
  * Hardened the self-node remediation daemon by enabling `readOnlyRootFilesystem` at the container level.

* **Tests**
  * Expanded end-to-end coverage to validate daemon security settings and pod identity constraints.
  * Improved controller test cleanup and deletion verification to more reliably confirm resource removal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->