### PR TITLE
fix: wire MIN_PEERS_FOR_REMEDIATION env var into the agent config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -322,6 +322,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 	peerDialTimeout := getDurEnvVarOrDie("PEER_DIAL_TIMEOUT")         //timeout for establishing connection to peer
 	peerRequestTimeout := getDurEnvVarOrDie("PEER_REQUEST_TIMEOUT")   //timeout for each peer request
 	peerHealthDefaultPort := getIntEnvVarOrDie("HOST_PORT")
+	minPeersForRemediation := getIntEnvVarOrDie("MIN_PEERS_FOR_REMEDIATION") //minimum peers required to remediate; if fewer peers are found the node will not self-remediate on API errors
 
 	// it's fine when the watchdog is nil!
 	rebooter := reboot.NewWatchdogRebooter(wd, ctrl.Log.WithName("rebooter"))
@@ -349,6 +350,7 @@ func initSelfNodeRemediationAgent(mgr manager.Manager) {
 		PeerDialTimeout:           peerDialTimeout,
 		PeerRequestTimeout:        peerRequestTimeout,
 		PeerHealthPort:            peerHealthDefaultPort,
+		MinPeersForRemediation:    minPeersForRemediation,
 		MaxTimeForNoPeersResponse: reboot.MaxTimeForNoPeersResponse,
 		Recorder:                  mgr.GetEventRecorderFor("ApiConnectivityCheck"),
 	}


### PR DESCRIPTION
## Problem

The on-node agent never reads the `MIN_PEERS_FOR_REMEDIATION` environment variable, so `ApiConnectivityCheckConfig.MinPeersForRemediation` is always left at Go's zero value (`0`) — no matter what `SelfNodeRemediationConfig.spec.minPeersForRemediation` is set to.

The plumbing is complete on every side *except* the agent's consumption of the value:

- The CRD field exists (`api/v1alpha1/selfnoderemediationconfig_types.go`, default `1`).
- The operator renders it into the agent DaemonSet as an env var: `install/self-node-remediation-deamonset.yaml` sets `MIN_PEERS_FOR_REMEDIATION`, populated from the CR in `internal/controller/selfnoderemediationconfig_controller.go`.
- The consumer logic uses it (`internal/apicheck/check.go`, `getWorkerPeersResponse`).
- **But `cmd/main.go` (`initSelfNodeRemediationAgent`) never reads `MIN_PEERS_FOR_REMEDIATION` into the config struct** — unlike its siblings `MAX_API_ERROR_THRESHOLD`, `API_SERVER_TIMEOUT`, etc. The env var is set on the pod and silently ignored.

## Impact

With the effective value stuck at `0`, the guard in `getWorkerPeersResponse`:

```go
if len(peersToAsk) < c.config.MinPeersForRemediation { // 0 < 0 is never true
    return peers.Response{IsHealthy: true, Reason: peers.HealthyBecauseNoPeersWereFound}
}
if len(peersToAsk) == 0 {
    // "Marking node as unhealthy due to being isolated ..."
    return peers.Response{IsHealthy: false, Reason: peers.UnHealthyBecauseNodeIsIsolated}
}
```

is unreachable. Any node that finds **zero** peers falls straight through to the `isolated → IsHealthy:false → reboot` branch. The `minPeersForRemediation` safeguard is effectively dead code: setting it to any value has no effect on the running agent.

This is most damaging during a **cluster-wide API-server/etcd disruption**: agents that (for any reason) have an empty peer list at that moment declare themselves isolated and self-reboot — precisely the mass-reboot scenario this option was introduced to prevent. The agent even logs `{"minPeersRequired": 0, "actualNumPeersFound": 0}` while the CR reads `1`, which is the observable symptom of this bug.

This has been present since the option was introduced (the commit added the CRD field, operator env rendering, and consumer logic, but did not add the read in the agent entrypoint), and is still present on `main`.

## Fix

Read `MIN_PEERS_FOR_REMEDIATION` in `initSelfNodeRemediationAgent` the same way as the neighbouring `MAX_API_ERROR_THRESHOLD`, and pass it into `ApiConnectivityCheckConfig`:

```go
minPeersForRemediation := getIntEnvVarOrDie("MIN_PEERS_FOR_REMEDIATION")
...
MinPeersForRemediation: minPeersForRemediation,
```

The operator already injects this env var into the DaemonSet, so no operator-side change is required. Cross-compiles cleanly for `linux/amd64`.

## Notes / open items (draft)

- Opened as **draft**: happy to add unit-test coverage asserting the agent honours `minPeersForRemediation` (e.g. that a 0-peer node with `minPeersForRemediation >= 1` is treated as healthy and does not remediate) if that's the preferred direction.
- `getIntEnvVarOrDie` will fail fast if the env var is absent, matching the existing pattern; since the operator always renders it (with the CRD default), managed deployments are unaffected. If backward-compatibility with externally-managed DaemonSets that omit the var is a concern, this could default instead of dying — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a minimum peer threshold used during remediation checks.
  * The remediation agent now respects a new environment setting to better control when connectivity checks trigger actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->