### PR TITLE
Use Node API bootID for e2e reboot detection

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 	controlPlaneNodes := &v1.NodeList{}
 
 	var nodeUnderTest *v1.Node
-	var oldBootTime *time.Time
+	var oldBootID string
 	var oldSnrPodName string
 
 	BeforeEach(func() {
@@ -73,16 +73,14 @@ var _ = Describe("Self Node Remediation E2E", func() {
 	})
 
 	JustBeforeEach(func() {
-		var err error
-		oldBootTime, err = utils.GetBootTime(context.Background(), k8sClientSet, nodeUnderTest, testNamespace)
-		Expect(err).ToNot(HaveOccurred())
+		oldBootID = utils.GetBootID(context.Background(), k8sClientSet, nodeUnderTest)
 		oldSnrPodName = findSnrPod(nodeUnderTest).GetName()
 	})
 
 	verifyRemediationSucceeds := func(snr *v1alpha1.SelfNodeRemediation) {
 		// this does not 100% check if the pod was deleted by SNR, could be by reboot...
 		checkPodDeleted(oldSnrPodName)
-		utils.CheckReboot(context.Background(), k8sClientSet, nodeUnderTest, oldBootTime, testNamespace)
+		utils.CheckReboot(context.Background(), k8sClientSet, nodeUnderTest, oldBootID)
 		// Simulate NHC deleting SNR
 		deleteAndWait(snr)
 		checkNoScheduleTaintRemoved(nodeUnderTest)
@@ -151,7 +149,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 				})
 
 				It("should not remediate", func() {
-					utils.CheckNoReboot(context.Background(), k8sClientSet, nodeUnderTest, oldBootTime, testNamespace)
+					utils.CheckNoReboot(context.Background(), k8sClientSet, nodeUnderTest, oldBootID)
 					checkSnrLogs(nodeUnderTest, []string{"failed to check api server", "There is at least one peer " +
 						"who thinks this node healthy"}, testStartTime)
 				})
@@ -164,7 +162,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 				//    - kill connectivity on all nodes
 				//    - verify nodeUnderTest does not reboot and isn't deleted
 
-				bootTimes := make(map[string]*time.Time)
+				bootIDs := make(map[string]string)
 
 				BeforeEach(func() {
 					wg := sync.WaitGroup{}
@@ -172,10 +170,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 						wg.Add(1)
 						worker := &workerNodes.Items[i]
 
-						// and the last boot time
-						t, err := utils.GetBootTime(context.Background(), k8sClientSet, worker, testNamespace)
-						Expect(err).ToNot(HaveOccurred())
-						bootTimes[worker.GetName()] = t
+						bootIDs[worker.GetName()] = utils.GetBootID(context.Background(), k8sClientSet, worker)
 
 						go func() {
 							defer GinkgoRecover()
@@ -198,7 +193,7 @@ var _ = Describe("Self Node Remediation E2E", func() {
 						go func() {
 							defer GinkgoRecover()
 							defer wg.Done()
-							utils.CheckNoReboot(context.Background(), k8sClientSet, worker, bootTimes[worker.GetName()], testNamespace)
+							utils.CheckNoReboot(context.Background(), k8sClientSet, worker, bootIDs[worker.GetName()])
 							checkSnrLogs(worker, []string{"failed to check api server", "nodes couldn't access the api-server"}, testStartTime)
 						}()
 					}

--- a/e2e/utils/command.go
+++ b/e2e/utils/command.go
@@ -37,56 +37,52 @@ var (
 	log = ctrl.Log.WithName("testutils")
 )
 
-func CheckReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node, oldBootTime *time.Time, testNamespace string) {
-	By("checking reboot")
-	log.Info("boot time", "old", oldBootTime)
-	EventuallyWithOffset(1, func() time.Time {
-		newBootTime, err := getBootTime(ctx, c, node.GetName(), testNamespace)
-		if err != nil {
-			return time.Time{}
-		}
-		log.Info("boot time", "new", newBootTime)
-		return *newBootTime
-	}, nodeRebootedTimeout, 1*time.Minute).Should(BeTemporally(">", *oldBootTime))
-}
-
-func CheckNoReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node, oldBootTime *time.Time, testNamespace string) {
-	By("checking no reboot")
-	log.Info("boot time", "old", oldBootTime)
-	ConsistentlyWithOffset(1, func() time.Time {
-		newBootTime, err := getBootTime(ctx, c, node.GetName(), testNamespace)
-		if err != nil {
-			log.Error(err, "failed to get boot time, might retry")
-			return time.Time{}
-		}
-		log.Info("boot time", "new", newBootTime)
-		return *newBootTime
-	}, nodeRebootedTimeout, 1*time.Minute).Should(BeTemporally("==", *oldBootTime))
-}
-
-// GetBootTime gets the boot time of the given node by running a pod on it executing uptime command
-func GetBootTime(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node, testNamespace string) (*time.Time, error) {
-	var bootTime *time.Time
+// GetBootID returns the boot ID of the node from the Kubernetes Node API.
+// Boot ID is a kernel-generated UUID that changes on every reboot.
+func GetBootID(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node) string {
+	var bootID string
 	EventuallyWithOffset(1, func() error {
-		var err error
-		bootTime, err = getBootTime(ctx, c, node.GetName(), testNamespace)
-		return err
-	}, nodeExecTimeout, 30*time.Second).ShouldNot(HaveOccurred(), "Could not get boot time on target node")
-	return bootTime, nil
+		n, err := c.CoreV1().Nodes().Get(ctx, node.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		bootID = n.Status.NodeInfo.BootID
+		if bootID == "" {
+			return fmt.Errorf("boot ID is empty for node %s", node.GetName())
+		}
+		return nil
+	}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred(), "Could not get boot ID on node %s", node.GetName())
+	return bootID
 }
 
-func getBootTime(ctx context.Context, c *kubernetes.Clientset, nodeName string, ns string) (*time.Time, error) {
-	output, err := RunCommandInCluster(ctx, c, nodeName, ns, "dnf install procps -y >/dev/null 2>&1 && uptime -s")
-	if err != nil {
-		return nil, err
-	}
+func CheckReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node, oldBootID string) {
+	By("checking reboot")
+	log.Info("boot ID", "old", oldBootID)
+	EventuallyWithOffset(1, func() string {
+		n, err := c.CoreV1().Nodes().Get(ctx, node.GetName(), metav1.GetOptions{})
+		if err != nil {
+			log.Info("failed to get node for boot ID, will retry", "error", err)
+			return oldBootID
+		}
+		newBootID := n.Status.NodeInfo.BootID
+		log.Info("boot ID", "new", newBootID)
+		return newBootID
+	}, nodeRebootedTimeout, 10*time.Second).ShouldNot(Equal(oldBootID))
+}
 
-	bootTime, err := time.Parse("2006-01-02 15:04:05", output)
-	if err != nil {
-		return nil, err
-	}
-
-	return &bootTime, nil
+func CheckNoReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node, oldBootID string) {
+	By("checking no reboot")
+	log.Info("boot ID", "old", oldBootID)
+	ConsistentlyWithOffset(1, func() string {
+		n, err := c.CoreV1().Nodes().Get(ctx, node.GetName(), metav1.GetOptions{})
+		if err != nil {
+			log.Error(err, "failed to get node for boot ID")
+			return oldBootID
+		}
+		newBootID := n.Status.NodeInfo.BootID
+		log.Info("boot ID", "new", newBootID)
+		return newBootID
+	}, nodeRebootedTimeout, 1*time.Minute).Should(Equal(oldBootID))
 }
 
 // RunCommandInCluster runs a command in a new pod in the cluster and returns the output

--- a/e2e/utils/command.go
+++ b/e2e/utils/command.go
@@ -57,6 +57,10 @@ func CheckReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node
 			return oldBootID
 		}
 		newBootID := n.Status.NodeInfo.BootID
+		if newBootID == "" {
+			log.Info("boot ID is empty, treating as transient and retaining old boot ID", "node", node.GetName())
+			return oldBootID
+		}
 		log.Info("boot ID", "new", newBootID)
 		return newBootID
 	}, nodeRebootedTimeout, 10*time.Second).ShouldNot(Equal(oldBootID))
@@ -72,6 +76,10 @@ func CheckNoReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.No
 			return oldBootID
 		}
 		newBootID := n.Status.NodeInfo.BootID
+		if newBootID == "" {
+			log.Info("boot ID is empty, treating as transient and retaining old boot ID", "node", node.GetName())
+			return oldBootID
+		}
 		log.Info("boot ID", "new", newBootID)
 		return newBootID
 	}, nodeRebootedTimeout, 1*time.Minute).Should(Equal(oldBootID))

--- a/e2e/utils/command.go
+++ b/e2e/utils/command.go
@@ -13,22 +13,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 const (
-	// this is time need to execute a command on the node, including potentially pod creation time
-	nodeExecTimeout = 300 * time.Second
-
-	// timeout for waiting for pod ready
-	podReadyTimeout = 120 * time.Second
-
 	// additional timeout (after podDeletedTimeout) when the node should be rebooted
 	nodeRebootedTimeout = 10 * time.Minute
 )
@@ -83,25 +75,6 @@ func CheckNoReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.No
 		log.Info("boot ID", "new", newBootID)
 		return newBootID
 	}, nodeRebootedTimeout, 1*time.Minute).Should(Equal(oldBootID))
-}
-
-// RunCommandInCluster runs a command in a new pod in the cluster and returns the output
-func RunCommandInCluster(ctx context.Context, c *kubernetes.Clientset, nodeName string, ns string, command string) (string, error) {
-
-	// create a pod and wait that it's running
-	pod := getPod(nodeName)
-	pod, err := c.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	err = waitForCondition(ctx, c, pod, corev1.PodReady, corev1.ConditionTrue, podReadyTimeout)
-	if err != nil {
-		return "", err
-	}
-
-	log.Info("helper pod is running, going to execute command")
-	return RunCommandInPod(ctx, c, pod, command)
 }
 
 // RunCommandInPod runs a command in a given pod and returns the output
@@ -159,63 +132,4 @@ func execCommandOnPod(ctx context.Context, c *kubernetes.Clientset, pod *corev1.
 	}
 
 	return outputBuf.Bytes(), nil
-}
-
-// waitForCondition waits until the pod will have specified condition type with the expected status
-func waitForCondition(ctx context.Context, c *kubernetes.Clientset, pod *corev1.Pod, conditionType corev1.PodConditionType, conditionStatus corev1.ConditionStatus, timeout time.Duration) error {
-	return wait.PollImmediateWithContext(ctx, time.Second, timeout, func(ctx context.Context) (bool, error) {
-		updatedPod := &corev1.Pod{}
-		var err error
-		if updatedPod, err = c.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err != nil {
-			return false, nil
-		}
-		for _, c := range updatedPod.Status.Conditions {
-			if c.Type == conditionType && c.Status == conditionStatus {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-}
-
-func getPod(nodeName string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "nhc-test-",
-			Labels: map[string]string{
-				"test": "",
-			},
-		},
-		Spec: corev1.PodSpec{
-			NodeName:    nodeName,
-			HostNetwork: true,
-			HostPID:     true,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  pointer.Int64(0),
-				RunAsGroup: pointer.Int64(0),
-			},
-			RestartPolicy: corev1.RestartPolicyNever,
-			Containers: []corev1.Container{
-				{
-					Name:  "test",
-					Image: "registry.access.redhat.com/ubi9/ubi:latest",
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: pointer.Bool(true),
-					},
-					Command: []string{"sleep", "10m"},
-				},
-			},
-			Tolerations: []corev1.Toleration{
-				{
-					Effect:   corev1.TaintEffectNoExecute,
-					Operator: corev1.TolerationOpExists,
-				},
-				{
-					Effect:   corev1.TaintEffectNoSchedule,
-					Operator: corev1.TolerationOpExists,
-				},
-			},
-			TerminationGracePeriodSeconds: pointer.Int64(600),
-		},
-	}
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the helper pod-based boot time detection in e2e tests with Kubernetes Node API bootID comparison.

## Why is this needed?

The e2e tests detect node reboots by creating a privileged helper pod on the target node to read boot time. After SysRq hard reboots, the container runtime's overlay storage can get corrupted, causing `CreateContainerError: readlink /var/lib/containers/storage/overlay/l: invalid argument`. This prevents the helper pod from starting, and the test times out even though the node rebooted successfully.

This has been blocking PRs #308, #309, #310, #311 across OCP 4.22, 4.23, and 5.0.

## Changes

**Commit 1: Use bootID for reboot detection**
- Replace `GetBootTime`/`CheckReboot`/`CheckNoReboot` with bootID-based equivalents that read `node.status.nodeInfo.bootID` directly from the Kubernetes Node API
- No helper pods needed — a single API call per check
- Update all call sites in the test file

**Commit 2: Remove dead helper pod code**
- Remove `RunCommandInCluster`, `getPod`, `waitForCondition` and dead constants (`nodeExecTimeout`, `podReadyTimeout`) — no longer called
- Keep `RunCommandInPod` and `execCommandOnPod` (still used by `killApiConnection` for API connectivity tests)

## How to verify

All e2e tests pass on OCP 4.22, 4.23, and 5.0.

## Jira

[RHWA-1305](https://redhat.atlassian.net/browse/RHWA-1305)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot/no-reboot end-to-end validation by comparing node Boot IDs instead of boot timestamps, including retries for Boot ID availability and a bounded polling window.
  * Enhanced logging during node status retrieval and Boot ID evaluation to clarify transient failures.

* **Tests**
  * Updated self node remediation end-to-end checks to track and verify per-node Boot ID changes using the new Boot ID-based validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->