### PR TITLE
Remove unnecessary hostPort from DaemonSet agent

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -95,6 +95,17 @@ var _ = Describe("Self Node Remediation E2E", func() {
 			ensureSnrRunning(workerNodes)
 		})
 
+		Describe("DaemonSet Security Configuration", func() {
+			It("should not expose hostPort on agent container", func() {
+				pod := findSnrPod(nodeUnderTest)
+				Expect(pod.Spec.Containers).ToNot(BeEmpty())
+				container := pod.Spec.Containers[0]
+				for _, port := range container.Ports {
+					Expect(port.HostPort).To(BeZero(), fmt.Sprintf("port %q should not have hostPort set", port.Name))
+				}
+			})
+		})
+
 		Describe("With API connectivity", func() {
 			// normal remediation
 			// - create SNR

--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -95,17 +95,6 @@ var _ = Describe("Self Node Remediation E2E", func() {
 			ensureSnrRunning(workerNodes)
 		})
 
-		Describe("DaemonSet Security Configuration", func() {
-			It("should not expose hostPort on agent container", func() {
-				pod := findSnrPod(nodeUnderTest)
-				Expect(pod.Spec.Containers).ToNot(BeEmpty())
-				container := pod.Spec.Containers[0]
-				for _, port := range container.Ports {
-					Expect(port.HostPort).To(BeZero(), fmt.Sprintf("port %q should not have hostPort set", port.Name))
-				}
-			})
-		})
-
 		Describe("With API connectivity", func() {
 			// normal remediation
 			// - create SNR
@@ -465,7 +454,15 @@ func ensureSnrRunning(nodes *v1.NodeList) {
 			defer wg.Done()
 			pod := findSnrPod(node)
 			utils.WaitForPodReady(k8sClient, pod)
+			verifyNoHostPort(pod)
 		}()
 	}
 	wg.Wait()
+}
+
+func verifyNoHostPort(pod *v1.Pod) {
+	ExpectWithOffset(1, pod.Spec.Containers).ToNot(BeEmpty())
+	for _, port := range pod.Spec.Containers[0].Ports {
+		ExpectWithOffset(1, port.HostPort).To(BeZero(), fmt.Sprintf("port %q should not have hostPort set", port.Name))
+	}
 }

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -84,7 +84,6 @@ spec:
         name: manager
         ports:
         - containerPort: {{.HostPort}}
-          hostPort: {{.HostPort}}
           name: self-n-r-port
           protocol: TCP
         resources:

--- a/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("SNR Config Test", func() {
 			Expect(len(container.Ports)).To(BeNumerically("==", 1))
 			port := container.Ports[0]
 			Expect(port.ContainerPort).To(BeEquivalentTo(30111))
-			Expect(port.HostPort).To(BeEquivalentTo(30111))
+			Expect(port.HostPort).To(BeZero())
 		})
 		When("Configuration has customized tolerations", func() {
 			var expectedToleration corev1.Toleration


### PR DESCRIPTION
## Why

The SNR DaemonSet manifest exposes `hostPort` alongside `containerPort` for the peer health gRPC
server. However, peer address discovery uses **pod IPs** (`pod.Status.PodIPs`), not node IPs,
making `hostPort` unnecessary. Removing it reduces the security surface flagged by DAST scanning
(KSV024 / AVD-KSV-0024) without affecting functionality.

## Changes

- Remove `hostPort: {{.HostPort}}` from the DaemonSet manifest template
- Update unit test assertion to expect zero `HostPort` value

## Evidence

| Component | Location | Finding |
|-----------|----------|---------|
| Peer discovery | `internal/peers/peers.go:159-163` | Uses `pod.Status.PodIPs[0]`, not node IPs |
| Client connection | `internal/apicheck/check.go:329` | Dials `PodIP:port` |
| gRPC server | `internal/peerhealth/server.go:70` | Listens on `0.0.0.0:port` (reachable via pod IP) |
| Codebase search | All Go files | Zero references to `node.Status.Addresses` for peer communication |

The `containerPort` alone is sufficient for pod-to-pod gRPC communication across nodes via
standard Kubernetes CNI networking (OVN-Kubernetes, Calico, etc.).

## Test plan

- [ ] Verify existing unit tests pass with updated assertion
- [ ] Run e2e remediation tests to confirm peer health checking works without hostPort
- [ ] Validate on OCP cluster with OVN-Kubernetes CNI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the node-remediation DaemonSet so the agent listens on the container port rather than binding a host port.
  * Adjusted installation and readiness validation to match the new port behavior.
* **Tests**
  * Enhanced end-to-end coverage to confirm the SNR agent pods do not set any `hostPort` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->