### PR TITLE
Fix e2e test robustness: logging, pod lifecycle, Gomega patterns

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -293,7 +293,7 @@ func createSNR(node *v1.Node, remediationStrategy v1alpha1.RemediationStrategyTy
 		_ = k8sClient.Delete(context.Background(), snr)
 		Eventually(func(g Gomega) {
 			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(snr), snr)
-			Expect(errors.IsNotFound(err)).To(BeTrue())
+			g.Expect(errors.IsNotFound(err)).To(BeTrue())
 		}, 2*time.Minute, 10*time.Second).Should(Succeed())
 	})
 	return snr
@@ -395,7 +395,7 @@ func findSnrPod(node *v1.Node) *v1.Pod {
 		}
 		for i := range pods.Items {
 			pod := pods.Items[i]
-			if pod.Spec.NodeName == node.GetName() {
+			if pod.Spec.NodeName == node.GetName() && pod.DeletionTimestamp == nil {
 				snrPod = &pod
 				return true
 			}

--- a/e2e/utils/command.go
+++ b/e2e/utils/command.go
@@ -61,7 +61,11 @@ func CheckReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.Node
 			log.Info("boot ID is empty, treating as transient and retaining old boot ID", "node", node.GetName())
 			return oldBootID
 		}
-		log.Info("boot ID", "new", newBootID)
+		if newBootID != oldBootID {
+			log.Info("boot ID changed", "old", oldBootID, "new", newBootID)
+		} else {
+			log.Info("boot ID unchanged, waiting for reboot", "current", newBootID)
+		}
 		return newBootID
 	}, nodeRebootedTimeout, 10*time.Second).ShouldNot(Equal(oldBootID))
 }
@@ -80,7 +84,11 @@ func CheckNoReboot(ctx context.Context, c *kubernetes.Clientset, node *corev1.No
 			log.Info("boot ID is empty, treating as transient and retaining old boot ID", "node", node.GetName())
 			return oldBootID
 		}
-		log.Info("boot ID", "new", newBootID)
+		if newBootID != oldBootID {
+			log.Info("boot ID changed unexpectedly", "old", oldBootID, "new", newBootID)
+		} else {
+			log.Info("boot ID unchanged", "current", newBootID)
+		}
 		return newBootID
 	}, nodeRebootedTimeout, 1*time.Minute).Should(Equal(oldBootID))
 }

--- a/e2e/utils/pod.go
+++ b/e2e/utils/pod.go
@@ -33,8 +33,8 @@ func GetLogs(c *kubernetes.Clientset, pod *corev1.Pod, since *metav1.Time) (stri
 }
 
 func WaitForPodReady(c client.Client, pod *corev1.Pod) {
-	EventuallyWithOffset(1, func() corev1.ConditionStatus {
-		ExpectWithOffset(1, c.Get(context.Background(), client.ObjectKeyFromObject(pod), pod)).ToNot(HaveOccurred())
+	EventuallyWithOffset(1, func(g Gomega) corev1.ConditionStatus {
+		g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(pod), pod)).ToNot(HaveOccurred())
 		for _, cond := range pod.Status.Conditions {
 			if cond.Type == corev1.PodReady {
 				return cond.Status


### PR DESCRIPTION
## Why

During the [RHWA-1305](https://redhat.atlassian.net/browse/RHWA-1305) investigation of SNR e2e failures across OCP 4.22/4.23/5.0, I have identified several e2e test issues:

- **Misleading boot ID logs**: `CheckReboot`/`CheckNoReboot` logged every polled boot ID as `"new"` even when it hadn't changed, producing confusing build-log output (e.g. 25 lines of `{"new": "<same-uuid>"}` before the actual change).

- **Stale pod references**: `findSnrPod` could return a Terminating pod after a node reboot, causing 404 errors in `WaitForPodReady`. This was the root cause of the PR#314/4.22 test failures (Tests 3+4 failed/panicked).

- **Gomega anti-patterns**: `WaitForPodReady` used global `ExpectWithOffset` inside `EventuallyWithOffset`, which panics instead of retrying on transient errors.
Similarly, `createSNR`'s DeferCleanup used global `Expect` inside a `func(g Gomega)` callback, defeating the retry mechanism.

## What

1. **Boot ID logging**: Replace single `"new"` log line with conditional messages that distinguish "unchanged, waiting for reboot" from "changed" (with both old and new values).

2. **findSnrPod**: Filter out pods with `DeletionTimestamp != nil` (Terminating state), matching the Kubernetes e2e framework pattern for DaemonSet pod filtering.

3. **WaitForPodReady**: Migrate from `ExpectWithOffset` (global assertion) to the `func(g Gomega)` callback pattern recommended by Gomega docs, so `Eventually` retries on transient API errors instead of panicking.

4. **createSNR**: Use `g.Expect` instead of global `Expect` inside the `Eventually(func(g Gomega))` block in DeferCleanup.

## Issue

Related to [RHWA-1305](https://redhat.atlassian.net/browse/RHWA-1305) (SNR e2e worker-node reboot failures investigation).

## Test plan

- [ ] `go build ./e2e/...` and `go vet ./e2e/...` pass locally
- [ ] CI e2e tests pass on OCP 4.22, 4.23, and 5.0
- [ ] Verify build-log.txt shows clear "boot ID unchanged" / "boot ID changed" messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod readiness polling to assert failures more precisely when the pod `Get` fails or the expected ready condition isn’t reached.
  * Tightened pod selection during self-node remediation to exclude pods marked for deletion.
  * Enhanced reboot validation logs to clearly indicate whether the node’s `BootID` changed.

* **Tests**
  * Updated end-to-end remediation and reboot checks to improve reliability of async assertions and reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->