### PR TITLE
Add NetworkPolicy RBAC permission

### DIFF
--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -203,6 +203,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - security.openshift.io
           resourceNames:
           - privileged

--- a/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/self-node-remediation.clusterserviceversion.yaml
@@ -211,6 +211,14 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - security.openshift.io
           resourceNames:
           - privileged

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -75,6 +75,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - privileged

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -83,6 +83,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - privileged

--- a/internal/controller/selfnoderemediation_controller.go
+++ b/internal/controller/selfnoderemediation_controller.go
@@ -143,6 +143,7 @@ func (r *SelfNodeRemediationReconciler) SetupWithManager(mgr ctrl.Manager) error
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machines,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=list;get;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 func (r *SelfNodeRemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (returnResult ctrl.Result, returnErr error) {
 	if r.IsAgent {


### PR DESCRIPTION
## Summary

Add `networking.k8s.io/networkpolicies` RBAC (create, delete, update) to allow managing NetworkPolicies for operand workloads.

## Changes

- Add kubebuilder RBAC marker to controller
- Regenerate `config/rbac/role.yaml`
- Regenerate bundle CSV

## Test plan

- [x] `make manifests` — RBAC generated correctly
- [x] `make bundle-reset` — bundle validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)