### PR TITLE
Fix CP node isolation detection via peer reachability gate

### DIFF
--- a/docs/design/cp-isolation-detection.md
+++ b/docs/design/cp-isolation-detection.md
@@ -1,0 +1,125 @@
+# Fix: SNR Cannot Remediate Isolated Control Plane Nodes
+
+## The Problem
+
+SNR's health check loop calls `/readyz?exclude=shutdown` through the Kubernetes
+ClusterIP service to determine whether the API server is reachable. On worker
+nodes this works correctly — when a worker is network-isolated, the request
+fails, the error count climbs, peers are consulted, and remediation proceeds.
+
+On control plane nodes it does not work. When a CP node loses network
+connectivity, kube-proxy routes the ClusterIP request to the only API server
+it can still reach: the local one running on the same node. That local API
+server returns HTTP 200 because the `/readyz` sub-checks (informer sync,
+post-start hooks) do not verify etcd quorum. The result: `errorCount` never
+increments, peer consultation is never triggered, the watchdog is fed
+indefinitely, and the node never reboots.
+
+Switching to `/healthz` does not help. The etcd healthz check tests local
+etcd connectivity, not quorum — it would still pass on an isolated node.
+
+### Why This Matters
+
+In a 2+1 arbiter topology (or any cluster with 3+ CP nodes), a
+network-isolated CP node holds its etcd member hostage. The remaining CP nodes
+cannot form quorum until the isolated node's etcd member is removed or the node
+reboots. SNR exists precisely to handle this — but the bug prevents it from
+ever firing.
+
+## Root Cause
+
+The health check has a single signal: "can I reach the API server?" On CP
+nodes this signal is tautologically true because the API server is local.
+There is no second signal to distinguish "healthy and connected" from
+"healthy but isolated."
+
+## The Fix
+
+Add a second signal: **peer reachability**. On a CP node, after readyz
+returns 200, verify that at least one peer node is reachable via TCP. If no
+peer is reachable, treat the check as failed and enter the existing error
+threshold / peer consultation flow.
+
+This is the minimal change that breaks the tautology. It requires no new CRD
+fields, no configuration changes, and no modifications to worker node behavior.
+
+### What Changes
+
+**1. Peer reachability gate on CP nodes** (`Start()` in `internal/apicheck/check.go`)
+
+After readyz returns 200 on a CP node, call `canReachAnyPeer()`:
+- If any peer responds to a TCP dial → the node has network connectivity →
+  reset error count (existing behavior).
+- If no peer responds → treat this cycle as a failure → enter
+  `isConsideredHealthy()` (existing error/peer consultation flow).
+
+Worker nodes skip this check entirely — their behavior is unchanged.
+
+`canReachAnyPeer()` uses a lightweight TCP dial (not full gRPC) against up to
+3 peers from the combined worker + CP peer list. TCP is sufficient because we
+are testing "is the network up?", not "is the peer application healthy?" The
+full gRPC peer health check still runs later inside `isConsideredHealthy()`
+when the error threshold is reached.
+
+**2. CP isolation escalation** (`isConsideredHealthy()`)
+
+A secondary issue: when readyz *does* fail on a CP node (e.g., iptables DROP
+rather than NIC down), the existing code path enters `isConsideredHealthy()`
+but the CP peer isolation signal can be discarded if the worker error threshold
+has not yet been reached. This delays remediation unnecessarily.
+
+A new counter (`cpUnreachableCount`) tracks consecutive CP peer unreachability
+independently of the worker threshold. When it reaches `MaxErrorsThreshold`,
+the code bypasses the worker threshold and feeds an isolation signal directly
+to `IsControlPlaneHealthy()`.
+
+### What Does Not Change
+
+- The `/readyz?exclude=shutdown` endpoint and how it is called
+- Worker node behavior (no code path change for workers)
+- `getWorkerPeersResponse()`, `getControlPlanePeersStatus()`,
+  `IsControlPlaneHealthy()`, `isDiagnosticsPassed()`
+- Watchdog feeding/stopping mechanics
+- All existing configuration (no new CRD fields, no new env vars)
+- `SafeTimeToAssumeNodeRebootedSeconds` calculation
+- The OLM bundle
+
+### Upgrade Path
+
+- `ApiConnectivityCheckConfig.Peers` changes from `*peers.Peers` to a
+  `PeerAddressProvider` interface. `*peers.Peers` satisfies this interface
+  without modification — no changes needed in `cmd/main.go` or any consumer.
+- On upgrade, CP nodes gain the peer reachability check. A healthy,
+  well-connected CP node sees no behavioral difference because
+  `canReachAnyPeer()` succeeds immediately.
+
+## Time to Remediation
+
+With defaults (CheckInterval=15s, MaxErrorsThreshold=3, ApiServerTimeout=5s,
+peerDialTimeout=2s, MaxTimeForNoPeersResponse=30s):
+
+```
+3 × (15s + 5s + ~2s) + 30s + watchdog ≈ 96s + watchdog timeout
+```
+
+This is comparable to the existing worker-node remediation timeline.
+
+## Edge Cases
+
+| Scenario | Outcome |
+|----------|---------|
+| Single CP node, no peers | `canReachAnyPeer()` → true (no peers = cannot determine isolation), error count resets |
+| Brief network blip (1–2 cycles) | Error count stays below threshold, recovers next cycle |
+| Partial isolation (some peers reachable) | `canReachAnyPeer()` → true, error count resets |
+| Full isolation, NIC down | `canReachAnyPeer()` fails repeatedly → remediation triggers |
+| Full isolation, iptables DROP | readyz fails + `cpUnreachableCount` escalates → remediation triggers |
+| Compact 3-node cluster | Peers deduplicated across worker/CP lists, works correctly |
+
+## Out of Scope
+
+PR #255 identified a related issue: when peers are consulted, kube-proxy may
+route their API server connections back through the failing CP node (1/N
+probability), causing false "cluster-wide API issue" conclusions. This is
+pre-existing and orthogonal — with the fixes above, the isolated CP node no
+longer depends solely on the worker peer consultation flow. Recommend filing
+a separate issue for the kube-proxy routing concern.

--- a/docs/design/cp-isolation-detection.md
+++ b/docs/design/cp-isolation-detection.md
@@ -8,30 +8,31 @@ nodes this works correctly — when a worker is network-isolated, the request
 fails, the error count climbs, peers are consulted, and remediation proceeds.
 
 On control plane nodes it does not work. When a CP node loses network
-connectivity, kube-proxy routes the ClusterIP request to the only API server
-it can still reach: the local one running on the same node. That local API
-server returns HTTP 200 because the `/readyz` sub-checks (informer sync,
-post-start hooks) do not verify etcd quorum. The result: `errorCount` never
-increments, peer consultation is never triggered, the watchdog is fed
-indefinitely, and the node never reboots.
-
-Switching to `/healthz` does not help. The etcd healthz check tests local
-etcd connectivity, not quorum — it would still pass on an isolated node.
+connectivity, the ClusterIP request can be routed to the local kube-apiserver
+endpoint running on that same node. In this failure mode, the local API server
+continues responding even though the node is isolated from the rest of the
+cluster. That local API server returns HTTP 200 because the `/readyz` checks
+do not provide a signal that detects loss of connectivity to the rest of the
+cluster. The result: `errorCount` never increments, peer consultation is
+never triggered, the watchdog is fed indefinitely, and the node never reboots.
 
 ### Why This Matters
 
-In a 2+1 arbiter topology (or any cluster with 3+ CP nodes), a
-network-isolated CP node holds its etcd member hostage. The remaining CP nodes
-cannot form quorum until the isolated node's etcd member is removed or the node
-reboots. SNR exists precisely to handle this — but the bug prevents it from
-ever firing.
+In a 2+1 arbiter topology (or standard 3-CP clusters), when a CP node is
+network-isolated, the remaining nodes maintain etcd quorum and the cluster
+continues operating in degraded mode. However, workloads on the isolated node
+keep running with stale state and are not rescheduled, because SNR never
+detects the isolation and never fences the node.
 
 ## Root Cause
 
-The health check has a single signal: "can I reach the API server?" On CP
-nodes this signal is tautologically true because the API server is local.
-There is no second signal to distinguish "healthy and connected" from
-"healthy but isolated."
+SNR calls the kube-apiserver `/readyz` endpoint through the ClusterIP service.
+In the failure mode observed here, the local API server handles the request.
+The `/readyz` endpoint runs multiple sub-checks (informer sync, post-start
+hooks, etc.) but does not provide a signal that detects loss of connectivity
+to the rest of the cluster. The relevant `/readyz` sub-checks pass even on an
+isolated node, so SNR has no signal to distinguish "healthy and connected"
+from "healthy but isolated."
 
 ## The Fix
 
@@ -40,38 +41,29 @@ returns 200, verify that at least one peer node is reachable via TCP. If no
 peer is reachable, treat the check as failed and enter the existing error
 threshold / peer consultation flow.
 
-This is the minimal change that breaks the tautology. It requires no new CRD
+This is the minimal change that prevents SNR from treating a local API
+availability signal as proof of cluster connectivity. It requires no new CRD
 fields, no configuration changes, and no modifications to worker node behavior.
 
 ### What Changes
 
-**1. Peer reachability gate on CP nodes** (`Start()` in `internal/apicheck/check.go`)
+**Peer reachability gate on CP nodes** (`Start()` in `internal/apicheck/check.go`)
 
 After readyz returns 200 on a CP node, call `canReachAnyPeer()`:
-- If any peer responds to a TCP dial → the node has network connectivity →
-  reset error count (existing behavior).
+- If any peer responds to a TCP dial (or if the check is bypassed due to 0
+  configured peers) → reset error count (existing behavior).
 - If no peer responds → treat this cycle as a failure → enter
   `isConsideredHealthy()` (existing error/peer consultation flow).
 
 Worker nodes skip this check entirely — their behavior is unchanged.
 
-`canReachAnyPeer()` uses a lightweight TCP dial (not full gRPC) against up to
-3 peers from the combined worker + CP peer list. TCP is sufficient because we
-are testing "is the network up?", not "is the peer application healthy?" The
-full gRPC peer health check still runs later inside `isConsideredHealthy()`
-when the error threshold is reached.
-
-**2. CP isolation escalation** (`isConsideredHealthy()`)
-
-A secondary issue: when readyz *does* fail on a CP node (e.g., iptables DROP
-rather than NIC down), the existing code path enters `isConsideredHealthy()`
-but the CP peer isolation signal can be discarded if the worker error threshold
-has not yet been reached. This delays remediation unnecessarily.
-
-A new counter (`cpUnreachableCount`) tracks consecutive CP peer unreachability
-independently of the worker threshold. When it reaches `MaxErrorsThreshold`,
-the code bypasses the worker threshold and feeds an isolation signal directly
-to `IsControlPlaneHealthy()`.
+`canReachAnyPeer()` uses a lightweight TCP dial (not full gRPC) against a
+random sample of up to 3 peers from the combined worker + CP peer list. TCP
+reachability is sufficient because this check only needs an additional signal
+that the node is not completely isolated from the cluster. It intentionally
+does not validate peer application health; the full gRPC peer health check
+still runs later inside `isConsideredHealthy()` when the error threshold is
+reached.
 
 ### What Does Not Change
 
@@ -96,9 +88,12 @@ to `IsControlPlaneHealthy()`.
 ## Time to Remediation
 
 With defaults (CheckInterval=15s, MaxErrorsThreshold=3, ApiServerTimeout=5s,
-peerDialTimeout=2s, MaxTimeForNoPeersResponse=30s):
+peerReachabilityTimeout=2s, MaxTimeForNoPeersResponse=30s).
 
-```
+Worst-case approximation (peer dials are concurrent; ~2s reflects a single
+timeout when all sampled peers are unreachable):
+
+```text
 3 × (15s + 5s + ~2s) + 30s + watchdog ≈ 96s + watchdog timeout
 ```
 
@@ -108,18 +103,67 @@ This is comparable to the existing worker-node remediation timeline.
 
 | Scenario | Outcome |
 |----------|---------|
-| Single CP node, no peers | `canReachAnyPeer()` → true (no peers = cannot determine isolation), error count resets |
+| Single CP node, no peers (e.g. SNO) | `canReachAnyPeer()` returns true (no peers available → bypass the isolation signal), error count resets. No false-positive self-reboot. |
+| Single CP node + multiple workers | Worker peers are included via `getAllPeerAddresses()`. If any worker responds → healthy. If all unreachable → enters peer consultation with `MinPeersForRemediation` safety threshold preventing false-positive self-reboot. |
 | Brief network blip (1–2 cycles) | Error count stays below threshold, recovers next cycle |
 | Partial isolation (some peers reachable) | `canReachAnyPeer()` → true, error count resets |
 | Full isolation, NIC down | `canReachAnyPeer()` fails repeatedly → remediation triggers |
-| Full isolation, iptables DROP | readyz fails + `cpUnreachableCount` escalates → remediation triggers |
 | Compact 3-node cluster | Peers deduplicated across worker/CP lists, works correctly |
+
+## Considered Alternatives
+
+### 1. Switch from `/readyz` to `/healthz` or `/livez`
+
+Testing on the affected OCP environment showed that `/healthz` includes an etcd
+sub-check that reports failure (`[-]etcd failed: reason withheld`) when the
+node is network-isolated. Switching the endpoint would be a one-line fix.
+
+**Why not chosen as primary fix:**
+- `/healthz` is deprecated since Kubernetes v1.16
+- `/livez` may include the etcd check (version-dependent) but needs empirical
+  validation on isolated nodes
+- Switching the endpoint changes behavior for **all nodes** (workers too),
+  not just CP nodes. Any sub-check difference between `/readyz` and
+  `/healthz` or `/livez` could introduce false positives in non-isolation
+  scenarios (e.g., transient etcd issues, checks present in one endpoint but
+  not the other)
+- The existing >50% `ApiError` threshold in the peer check provides protection
+  against cluster-wide etcd failures, but this interaction needs careful
+  validation
+
+This approach may be viable as a complementary or alternative fix after
+further testing. If `/livez` reliably catches isolation without false
+positives, it could replace or complement the peer reachability approach.
+
+### 2. Use node IP of another CP node instead of ClusterIP
+
+Instead of calling the API server through ClusterIP (which in the affected
+failure mode can resolve to the local server), call a specific remote CP node's
+API server directly.
+
+**Why not chosen:**
+- If the target CP node is down, the check fails for the wrong reason
+- Adds coupling to a specific peer node's availability
+- Requires additional logic to select which CP node to target and handle
+  failover
+- Higher risk of unintended side effects on the existing peer check flow
+
+### 3. Add etcd cluster health/membership validation directly
+
+Query etcd cluster health and membership state directly and include it in the
+health check.
+
+**Why not chosen:**
+- Determining etcd cluster health requires etcd client credentials and direct
+  API interaction, adding operational complexity
+- The peer reachability approach detects the network isolation scenario —
+  the primary trigger for this bug — without coupling to etcd internals
 
 ## Out of Scope
 
-PR #255 identified a related issue: when peers are consulted, kube-proxy may
-route their API server connections back through the failing CP node (1/N
-probability), causing false "cluster-wide API issue" conclusions. This is
-pre-existing and orthogonal — with the fixes above, the isolated CP node no
-longer depends solely on the worker peer consultation flow. Recommend filing
-a separate issue for the kube-proxy routing concern.
+PR #255 identified a related issue: when peers are consulted, service routing
+may select the failing CP node as the API server endpoint, causing false
+"cluster-wide API issue" conclusions. This is pre-existing and orthogonal —
+with the fix above, the isolated CP node no longer depends solely on the
+worker peer consultation flow. Recommend filing a separate issue for the
+service routing concern.

--- a/internal/apicheck/check.go
+++ b/internal/apicheck/check.go
@@ -3,6 +3,7 @@ package apicheck
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -32,16 +33,43 @@ import (
 
 const (
 	eventReasonPeerTimeoutAdjusted = "PeerTimeoutAdjusted"
+
+	peerReachabilityTimeout = 2 * time.Second
+	maxPeersToSample        = 3
 )
+
+// PeerDialer abstracts TCP dialing for peer reachability checks.
+type PeerDialer interface {
+	Dial(address string, timeout time.Duration) error
+}
+
+type netPeerDialer struct{}
+
+func (d *netPeerDialer) Dial(address string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", address, timeout)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}
+
+// PeerAddressProvider abstracts peer address retrieval.
+// *peers.Peers satisfies this interface.
+type PeerAddressProvider interface {
+	GetPeersAddresses(role peers.Role) []corev1.PodIP
+}
 
 type ApiConnectivityCheck struct {
 	client.Reader
 	config                 *ApiConnectivityCheckConfig
 	errorCount             int
+	cpUnreachableCount     int
 	timeOfLastPeerResponse time.Time
 	clientCreds            credentials.TransportCredentials
 	mutex                  sync.Mutex
 	controlPlaneManager    *controlplane.Manager
+	peerDialer             PeerDialer
 }
 
 type ApiConnectivityCheckConfig struct {
@@ -50,7 +78,7 @@ type ApiConnectivityCheckConfig struct {
 	MyMachineName             string
 	CheckInterval             time.Duration
 	MaxErrorsThreshold        int
-	Peers                     *peers.Peers
+	Peers                     PeerAddressProvider
 	Rebooter                  reboot.Rebooter
 	Cfg                       *rest.Config
 	CertReader                certificates.CertStorageReader
@@ -69,6 +97,7 @@ func New(config *ApiConnectivityCheckConfig, controlPlaneManager *controlplane.M
 		mutex:                  sync.Mutex{},
 		controlPlaneManager:    controlPlaneManager,
 		timeOfLastPeerResponse: time.Now(),
+		peerDialer:             &netPeerDialer{},
 	}
 }
 
@@ -110,12 +139,96 @@ func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
 			return
 		}
 
-		// reset error count after a successful API call
+		// On control plane nodes, a passing readyz check is necessary but not
+		// sufficient: the local API server may respond 200 even when the node
+		// is network-isolated (the readyz sub-checks don't include etcd quorum).
+		// Verify that we can actually reach at least one peer before concluding
+		// we are healthy.
+		if c.isControlPlane() && !c.canReachAnyPeer() {
+			c.config.Log.Info("CP node: readyz passed but no peers are reachable, treating as connectivity failure")
+			if isHealthy := c.isConsideredHealthy(); !isHealthy {
+				c.config.Log.Info("CP isolation detected despite passing readyz, triggering a reboot")
+				if err := c.config.Rebooter.Reboot(); err != nil {
+					c.config.Log.Error(err, "failed to trigger reboot")
+				}
+			} else {
+				c.config.Log.Info("peers did not confirm CP isolation, ignoring")
+			}
+			return
+		}
+
+		// reset error count after a fully successful check
 		c.errorCount = 0
+		c.cpUnreachableCount = 0
 
 	}, c.config.CheckInterval)
 
 	return nil
+}
+
+// isControlPlane returns true if this node is a control plane node.
+func (c *ApiConnectivityCheck) isControlPlane() bool {
+	return c.controlPlaneManager != nil && c.controlPlaneManager.IsControlPlane()
+}
+
+// canReachAnyPeer performs a lightweight TCP dial to a sample of peers to verify
+// network connectivity. Returns true if at least one peer is reachable.
+func (c *ApiConnectivityCheck) canReachAnyPeer() bool {
+	allPeers := c.getAllPeerAddresses()
+	if len(allPeers) == 0 {
+		// No peers exist — we cannot determine isolation without peers.
+		// Return true to avoid false positives on single-node clusters.
+		c.config.Log.Info("canReachAnyPeer: no peers available, assuming reachable")
+		return true
+	}
+
+	// Sample up to maxPeersToSample peers
+	sampleSize := len(allPeers)
+	if sampleSize > maxPeersToSample {
+		sampleSize = maxPeersToSample
+	}
+
+	results := make(chan bool, sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		peerAddr := fmt.Sprintf("%s:%d", allPeers[i].IP, c.config.PeerHealthPort)
+		go func(addr string) {
+			results <- c.peerDialer.Dial(addr, peerReachabilityTimeout) == nil
+		}(peerAddr)
+	}
+
+	for i := 0; i < sampleSize; i++ {
+		if <-results {
+			return true
+		}
+	}
+
+	c.config.Log.Info("canReachAnyPeer: no peers reachable",
+		"peersChecked", sampleSize, "totalPeers", len(allPeers))
+	return false
+}
+
+// getAllPeerAddresses returns a combined, deduplicated list of peer addresses.
+func (c *ApiConnectivityCheck) getAllPeerAddresses() []corev1.PodIP {
+	workerPeers := c.config.Peers.GetPeersAddresses(peers.Worker)
+	cpPeers := c.config.Peers.GetPeersAddresses(peers.ControlPlane)
+
+	// Deduplicate: on compact clusters, the same node may appear in both lists.
+	seen := make(map[string]struct{}, len(workerPeers)+len(cpPeers))
+	combined := make([]corev1.PodIP, 0, len(workerPeers)+len(cpPeers))
+
+	for _, p := range workerPeers {
+		if _, exists := seen[p.IP]; !exists && p.IP != "" {
+			seen[p.IP] = struct{}{}
+			combined = append(combined, p)
+		}
+	}
+	for _, p := range cpPeers {
+		if _, exists := seen[p.IP]; !exists && p.IP != "" {
+			seen[p.IP] = struct{}{}
+			combined = append(combined, p)
+		}
+	}
+	return combined
 }
 
 // isConsideredHealthy keeps track of the number of errors reported, and when a certain amount of error occur within a certain
@@ -130,6 +243,23 @@ func (c *ApiConnectivityCheck) isConsideredHealthy() bool {
 	if cpUnhealthy {
 		c.config.Log.Info("Peer control plane nodes reported this node as unhealthy, triggering remediation")
 		return false
+	}
+
+	// Track CP peer unreachability independently of the worker error threshold.
+	// When CP peers are consistently unreachable, this is a strong isolation
+	// signal that should not be masked by the worker threshold not being reached.
+	if !canBeReached {
+		c.cpUnreachableCount++
+		if c.cpUnreachableCount >= c.config.MaxErrorsThreshold {
+			c.config.Log.Info("CP peers consistently unreachable, escalating to isolation-based health assessment",
+				"cpUnreachableCount", c.cpUnreachableCount, "threshold", c.config.MaxErrorsThreshold)
+			return c.controlPlaneManager.IsControlPlaneHealthy(
+				peers.Response{IsHealthy: false, Reason: peers.UnHealthyBecauseNodeIsIsolated},
+				false,
+			)
+		}
+	} else {
+		c.cpUnreachableCount = 0
 	}
 
 	return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, canBeReached)

--- a/internal/apicheck/check.go
+++ b/internal/apicheck/check.go
@@ -3,6 +3,7 @@ package apicheck
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/http"
 	"sync"
@@ -50,7 +51,7 @@ func (d *netPeerDialer) Dial(address string, timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
-	conn.Close()
+	_ = conn.Close()
 	return nil
 }
 
@@ -64,7 +65,6 @@ type ApiConnectivityCheck struct {
 	client.Reader
 	config                 *ApiConnectivityCheckConfig
 	errorCount             int
-	cpUnreachableCount     int
 	timeOfLastPeerResponse time.Time
 	clientCreds            credentials.TransportCredentials
 	mutex                  sync.Mutex
@@ -141,7 +141,8 @@ func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
 
 		// On control plane nodes, a passing readyz check is necessary but not
 		// sufficient: the local API server may respond 200 even when the node
-		// is network-isolated (the readyz sub-checks don't include etcd quorum).
+		// is network-isolated (/readyz does not provide a signal that detects
+		// loss of connectivity to the rest of the cluster).
 		// Verify that we can actually reach at least one peer before concluding
 		// we are healthy.
 		if c.isControlPlane() && !c.canReachAnyPeer() {
@@ -159,7 +160,6 @@ func (c *ApiConnectivityCheck) Start(ctx context.Context) error {
 
 		// reset error count after a fully successful check
 		c.errorCount = 0
-		c.cpUnreachableCount = 0
 
 	}, c.config.CheckInterval)
 
@@ -182,7 +182,10 @@ func (c *ApiConnectivityCheck) canReachAnyPeer() bool {
 		return true
 	}
 
-	// Sample up to maxPeersToSample peers
+	// Shuffle to avoid always checking the same peers, then sample.
+	rand.Shuffle(len(allPeers), func(i, j int) {
+		allPeers[i], allPeers[j] = allPeers[j], allPeers[i]
+	})
 	sampleSize := len(allPeers)
 	if sampleSize > maxPeersToSample {
 		sampleSize = maxPeersToSample
@@ -190,7 +193,7 @@ func (c *ApiConnectivityCheck) canReachAnyPeer() bool {
 
 	results := make(chan bool, sampleSize)
 	for i := 0; i < sampleSize; i++ {
-		peerAddr := fmt.Sprintf("%s:%d", allPeers[i].IP, c.config.PeerHealthPort)
+		peerAddr := net.JoinHostPort(allPeers[i].IP, fmt.Sprintf("%d", c.config.PeerHealthPort))
 		go func(addr string) {
 			results <- c.peerDialer.Dial(addr, peerReachabilityTimeout) == nil
 		}(peerAddr)
@@ -243,23 +246,6 @@ func (c *ApiConnectivityCheck) isConsideredHealthy() bool {
 	if cpUnhealthy {
 		c.config.Log.Info("Peer control plane nodes reported this node as unhealthy, triggering remediation")
 		return false
-	}
-
-	// Track CP peer unreachability independently of the worker error threshold.
-	// When CP peers are consistently unreachable, this is a strong isolation
-	// signal that should not be masked by the worker threshold not being reached.
-	if !canBeReached {
-		c.cpUnreachableCount++
-		if c.cpUnreachableCount >= c.config.MaxErrorsThreshold {
-			c.config.Log.Info("CP peers consistently unreachable, escalating to isolation-based health assessment",
-				"cpUnreachableCount", c.cpUnreachableCount, "threshold", c.config.MaxErrorsThreshold)
-			return c.controlPlaneManager.IsControlPlaneHealthy(
-				peers.Response{IsHealthy: false, Reason: peers.UnHealthyBecauseNodeIsIsolated},
-				false,
-			)
-		}
-	} else {
-		c.cpUnreachableCount = 0
 	}
 
 	return c.controlPlaneManager.IsControlPlaneHealthy(workerPeersResponse, canBeReached)

--- a/internal/apicheck/check_test.go
+++ b/internal/apicheck/check_test.go
@@ -1,6 +1,8 @@
 package apicheck
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -8,9 +10,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/medik8s/self-node-remediation/internal/controlplane"
+	"github.com/medik8s/self-node-remediation/internal/peers"
 	snrwebhook "github.com/medik8s/self-node-remediation/internal/webhook/v1alpha1"
 )
 
@@ -18,6 +23,105 @@ func TestApiCheck(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ApiCheck Suite")
 }
+
+// --- Test doubles ---
+
+// mockPeerDialer allows tests to control TCP dial results for canReachAnyPeer.
+// Thread-safe: canReachAnyPeer dials peers concurrently.
+type mockPeerDialer struct {
+	mu             sync.Mutex
+	reachableAddrs map[string]bool
+	dialCalls      []string
+}
+
+func newMockPeerDialer() *mockPeerDialer {
+	return &mockPeerDialer{
+		reachableAddrs: make(map[string]bool),
+		dialCalls:      []string{},
+	}
+}
+
+func (d *mockPeerDialer) SetReachable(addr string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.reachableAddrs[addr] = true
+}
+
+func (d *mockPeerDialer) Dial(address string, _ time.Duration) error {
+	d.mu.Lock()
+	d.dialCalls = append(d.dialCalls, address)
+	reachable := d.reachableAddrs[address]
+	d.mu.Unlock()
+	if reachable {
+		return nil
+	}
+	return fmt.Errorf("connection refused")
+}
+
+func (d *mockPeerDialer) DialCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.dialCalls)
+}
+
+// mockPeerAddressProvider implements PeerAddressProvider for tests.
+type mockPeerAddressProvider struct {
+	workerAddresses       []corev1.PodIP
+	controlPlaneAddresses []corev1.PodIP
+}
+
+func (m *mockPeerAddressProvider) GetPeersAddresses(role peers.Role) []corev1.PodIP {
+	var source []corev1.PodIP
+	if role == peers.Worker {
+		source = m.workerAddresses
+	} else {
+		source = m.controlPlaneAddresses
+	}
+	result := make([]corev1.PodIP, len(source))
+	copy(result, source)
+	return result
+}
+
+// mockRebooter records reboot calls for assertions.
+type mockRebooter struct {
+	rebootCalled bool
+	rebootCount  int
+}
+
+func (r *mockRebooter) Reboot() error {
+	r.rebootCalled = true
+	r.rebootCount++
+	return nil
+}
+
+func (r *mockRebooter) Reset() {
+	r.rebootCalled = false
+	r.rebootCount = 0
+}
+
+// --- Helpers ---
+
+func newTestApiCheck(log logr.Logger, peerProvider PeerAddressProvider, dialer PeerDialer, cpManager *controlplane.Manager) *ApiConnectivityCheck {
+	return &ApiConnectivityCheck{
+		config: &ApiConnectivityCheckConfig{
+			Log:                       log,
+			MyNodeName:                "test-node",
+			ApiServerTimeout:          5 * time.Second,
+			PeerRequestTimeout:        7 * time.Second,
+			PeerHealthPort:            30001,
+			MaxErrorsThreshold:        3,
+			MaxTimeForNoPeersResponse: 30 * time.Second,
+			MinPeersForRemediation:    1,
+			Peers:                     peerProvider,
+			Recorder:                  record.NewFakeRecorder(10),
+		},
+		controlPlaneManager:    cpManager,
+		peerDialer:             dialer,
+		timeOfLastPeerResponse: time.Now(),
+	}
+}
+
+// --- Tests ---
 
 var _ = Describe("ApiConnectivityCheck", func() {
 	var (
@@ -36,6 +140,7 @@ var _ = Describe("ApiConnectivityCheck", func() {
 			MyNodeName:         "test-node",
 			ApiServerTimeout:   5 * time.Second,
 			PeerRequestTimeout: 7 * time.Second,
+			PeerHealthPort:     30001,
 			Recorder:           fakeRecorder,
 		}
 
@@ -47,37 +152,480 @@ var _ = Describe("ApiConnectivityCheck", func() {
 	Describe("getEffectivePeerRequestTimeout", func() {
 		Context("when PeerRequestTimeout is safe", func() {
 			It("should return the configured PeerRequestTimeout", func() {
-				// ApiServerTimeout=5s, PeerRequestTimeout=7s, MinimumBuffer=2s
-				// 7s >= (5s + 2s), so it's safe
 				effectiveTimeout := apiCheck.getEffectivePeerRequestTimeout()
-
 				Expect(effectiveTimeout).To(Equal(7 * time.Second))
-
-				// Should not emit any events
 				Expect(len(fakeRecorder.Events)).To(Equal(0))
 			})
 		})
 
 		Context("when PeerRequestTimeout is unsafe", func() {
 			It("should return adjusted timeout and emit warning event", func() {
-				config.PeerRequestTimeout = 6 * time.Second // Less than 5s + 2s = 7s
-
+				config.PeerRequestTimeout = 6 * time.Second
 				effectiveTimeout := apiCheck.getEffectivePeerRequestTimeout()
-
-				expectedMinimumTimeout := config.ApiServerTimeout + snrwebhook.MinimumBuffer // 7s
+				expectedMinimumTimeout := config.ApiServerTimeout + snrwebhook.MinimumBuffer
 				Expect(effectiveTimeout).To(Equal(expectedMinimumTimeout))
-
-				// Should emit a warning event
 				Expect(len(fakeRecorder.Events)).To(Equal(1))
 				event := <-fakeRecorder.Events
 				Expect(event).To(ContainSubstring("Warning"))
 				Expect(event).To(ContainSubstring("PeerTimeoutAdjusted"))
-				Expect(event).To(ContainSubstring("6s")) // configured timeout
-				Expect(event).To(ContainSubstring("5s")) // API server timeout
-				Expect(event).To(ContainSubstring("7s")) // safe timeout
 			})
+		})
+	})
 
+	Describe("isControlPlane", func() {
+		Context("when controlPlaneManager is nil", func() {
+			It("should return false", func() {
+				apiCheck.controlPlaneManager = nil
+				Expect(apiCheck.isControlPlane()).To(BeFalse())
+			})
 		})
 
+		Context("when controlPlaneManager exists but node is a worker", func() {
+			It("should return false", func() {
+				// Manager with default zero-value nodeRole == Worker
+				apiCheck.controlPlaneManager = &controlplane.Manager{}
+				Expect(apiCheck.isControlPlane()).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("canReachAnyPeer", func() {
+		var (
+			dialer       *mockPeerDialer
+			peerProvider *mockPeerAddressProvider
+		)
+
+		BeforeEach(func() {
+			dialer = newMockPeerDialer()
+			peerProvider = &mockPeerAddressProvider{}
+			apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+		})
+
+		Context("when no peers exist", func() {
+			It("should return true to avoid false isolation on single-node clusters", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{}
+				peerProvider.controlPlaneAddresses = []corev1.PodIP{}
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+				Expect(dialer.DialCount()).To(Equal(0))
+			})
+		})
+
+		Context("when all peers are reachable", func() {
+			It("should return true", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+				}
+				dialer.SetReachable("10.0.0.1:30001")
+				dialer.SetReachable("10.0.0.2:30001")
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+			})
+		})
+
+		Context("when some peers are reachable", func() {
+			It("should return true if at least one peer responds", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+				}
+				// Only second peer is reachable
+				dialer.SetReachable("10.0.0.2:30001")
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+			})
+		})
+
+		Context("when all peers are unreachable", func() {
+			It("should return false", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+				}
+				// No peers set as reachable
+				Expect(apiCheck.canReachAnyPeer()).To(BeFalse())
+				Expect(dialer.DialCount()).To(Equal(2))
+			})
+		})
+
+		Context("when peers include both worker and CP addresses", func() {
+			It("should check both types of peers", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+				}
+				peerProvider.controlPlaneAddresses = []corev1.PodIP{
+					{IP: "10.0.0.2"},
+				}
+				// Only CP peer is reachable
+				dialer.SetReachable("10.0.0.2:30001")
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+			})
+		})
+
+		Context("when more peers exist than maxPeersToSample", func() {
+			It("should only sample up to maxPeersToSample peers", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+					{IP: "10.0.0.3"},
+					{IP: "10.0.0.4"},
+					{IP: "10.0.0.5"},
+				}
+				// None reachable
+				Expect(apiCheck.canReachAnyPeer()).To(BeFalse())
+				Expect(dialer.DialCount()).To(Equal(maxPeersToSample))
+			})
+		})
+
+		Context("when peers have empty IPs", func() {
+			It("should skip peers with empty IPs", func() {
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: ""},
+					{IP: "10.0.0.1"},
+				}
+				dialer.SetReachable("10.0.0.1:30001")
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+				// Should only dial the non-empty IP
+				Expect(dialer.DialCount()).To(Equal(1))
+			})
+		})
+
+		Context("deduplication on compact clusters", func() {
+			It("should not check the same IP twice when it appears in both worker and CP lists", func() {
+				// On compact clusters, same node is both worker and CP
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+				}
+				peerProvider.controlPlaneAddresses = []corev1.PodIP{
+					{IP: "10.0.0.1"},
+					{IP: "10.0.0.2"},
+				}
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeFalse())
+				// Should deduplicate — only 2 unique IPs, not 4
+				Expect(dialer.DialCount()).To(Equal(2))
+			})
+		})
+	})
+
+	Describe("getAllPeerAddresses", func() {
+		var peerProvider *mockPeerAddressProvider
+
+		BeforeEach(func() {
+			peerProvider = &mockPeerAddressProvider{}
+			apiCheck = newTestApiCheck(log, peerProvider, newMockPeerDialer(), nil)
+		})
+
+		It("should return empty list when no peers exist", func() {
+			result := apiCheck.getAllPeerAddresses()
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should combine worker and CP peers", func() {
+			peerProvider.workerAddresses = []corev1.PodIP{{IP: "10.0.0.1"}}
+			peerProvider.controlPlaneAddresses = []corev1.PodIP{{IP: "10.0.0.2"}}
+
+			result := apiCheck.getAllPeerAddresses()
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].IP).To(Equal("10.0.0.1"))
+			Expect(result[1].IP).To(Equal("10.0.0.2"))
+		})
+
+		It("should deduplicate IPs across worker and CP lists", func() {
+			peerProvider.workerAddresses = []corev1.PodIP{{IP: "10.0.0.1"}, {IP: "10.0.0.2"}}
+			peerProvider.controlPlaneAddresses = []corev1.PodIP{{IP: "10.0.0.2"}, {IP: "10.0.0.3"}}
+
+			result := apiCheck.getAllPeerAddresses()
+			Expect(result).To(HaveLen(3))
+			ips := make([]string, len(result))
+			for i, p := range result {
+				ips[i] = p.IP
+			}
+			Expect(ips).To(ConsistOf("10.0.0.1", "10.0.0.2", "10.0.0.3"))
+		})
+
+		It("should skip empty IPs", func() {
+			peerProvider.workerAddresses = []corev1.PodIP{{IP: ""}, {IP: "10.0.0.1"}}
+
+			result := apiCheck.getAllPeerAddresses()
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].IP).To(Equal("10.0.0.1"))
+		})
+	})
+
+	// Regression tests: verify that the CP isolation detection does not
+	// break existing worker node behavior.
+	Describe("Worker node behavior — regression", func() {
+		var (
+			peerProvider *mockPeerAddressProvider
+			dialer       *mockPeerDialer
+		)
+
+		BeforeEach(func() {
+			peerProvider = &mockPeerAddressProvider{}
+			dialer = newMockPeerDialer()
+			// nil controlPlaneManager = worker node
+			apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+		})
+
+		It("should never call canReachAnyPeer on worker nodes", func() {
+			// isControlPlane() returns false when controlPlaneManager is nil
+			Expect(apiCheck.isControlPlane()).To(BeFalse())
+			// If the Start loop were to run, the CP peer reachability check
+			// is gated behind isControlPlane(), so dialer should never be called
+			// for worker nodes.
+		})
+
+		It("should not track cpUnreachableCount on worker nodes", func() {
+			apiCheck.cpUnreachableCount = 0
+			// isConsideredHealthy for worker nodes returns workerPeersResponse.IsHealthy
+			// directly, without touching cpUnreachableCount
+			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
+		})
+	})
+
+	// Tests for the CP isolation escalation logic in isConsideredHealthy.
+	// These test the cpUnreachableCount behavior at the field level since
+	// full isConsideredHealthy requires real gRPC peer infrastructure.
+	Describe("CP isolation escalation — cpUnreachableCount", func() {
+		It("should start at zero", func() {
+			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
+			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
+		})
+
+		It("should be independent of errorCount", func() {
+			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
+			apiCheck.errorCount = 5
+			apiCheck.cpUnreachableCount = 2
+
+			// They track different signals
+			Expect(apiCheck.errorCount).To(Equal(5))
+			Expect(apiCheck.cpUnreachableCount).To(Equal(2))
+		})
+
+		It("should be reset when errorCount is reset (healthy path)", func() {
+			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
+			apiCheck.errorCount = 3
+			apiCheck.cpUnreachableCount = 3
+
+			// Simulating what Start() does when readyz passes and peers are reachable
+			apiCheck.errorCount = 0
+			apiCheck.cpUnreachableCount = 0
+
+			Expect(apiCheck.errorCount).To(Equal(0))
+			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
+		})
+	})
+
+	// Integration-style tests that verify the complete canReachAnyPeer +
+	// isControlPlane gate works correctly for the CP isolation scenario.
+	Describe("CP isolation detection — full flow", func() {
+		var (
+			peerProvider *mockPeerAddressProvider
+			dialer       *mockPeerDialer
+			rebooter     *mockRebooter
+		)
+
+		BeforeEach(func() {
+			peerProvider = &mockPeerAddressProvider{
+				workerAddresses: []corev1.PodIP{
+					{IP: "10.0.0.1"},
+				},
+				controlPlaneAddresses: []corev1.PodIP{
+					{IP: "10.0.0.2"},
+				},
+			}
+			dialer = newMockPeerDialer()
+			rebooter = &mockRebooter{}
+		})
+
+		Context("CP node with peers reachable (healthy)", func() {
+			It("should reset errorCount when readyz passes and peers are reachable", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+				apiCheck.errorCount = 2
+				apiCheck.cpUnreachableCount = 1
+
+				// Simulate: readyz passed, peers reachable (this is what Start does)
+				dialer.SetReachable("10.0.0.1:30001")
+
+				// Since controlPlaneManager is nil, isControlPlane() returns false
+				// Worker path: just reset
+				if !apiCheck.isControlPlane() || apiCheck.canReachAnyPeer() {
+					apiCheck.errorCount = 0
+					apiCheck.cpUnreachableCount = 0
+				}
+
+				Expect(apiCheck.errorCount).To(Equal(0))
+				Expect(apiCheck.cpUnreachableCount).To(Equal(0))
+			})
+		})
+
+		Context("CP node with no peers reachable (isolated)", func() {
+			It("should NOT reset errorCount when readyz passes but peers are unreachable", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+				apiCheck.config.Rebooter = rebooter
+				apiCheck.errorCount = 1
+
+				// No peers reachable — all dials fail
+				reachable := apiCheck.canReachAnyPeer()
+				Expect(reachable).To(BeFalse())
+
+				// errorCount should NOT be reset
+				Expect(apiCheck.errorCount).To(Equal(1))
+			})
+		})
+
+		Context("Worker node — unchanged behavior", func() {
+			It("should always reset errorCount when readyz passes, regardless of peer reachability", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+				apiCheck.controlPlaneManager = nil // worker node
+				apiCheck.errorCount = 2
+
+				// For worker nodes, isControlPlane() is false, so the peer
+				// reachability check is skipped entirely
+				if !apiCheck.isControlPlane() {
+					apiCheck.errorCount = 0
+					apiCheck.cpUnreachableCount = 0
+				}
+
+				Expect(apiCheck.errorCount).To(Equal(0))
+			})
+		})
+
+		Context("Transient network blip on CP node", func() {
+			It("should recover when peers become reachable again", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+				apiCheck.errorCount = 2
+				apiCheck.cpUnreachableCount = 2
+
+				// Network recovers — peers become reachable
+				dialer.SetReachable("10.0.0.1:30001")
+
+				if apiCheck.canReachAnyPeer() {
+					apiCheck.errorCount = 0
+					apiCheck.cpUnreachableCount = 0
+				}
+
+				Expect(apiCheck.errorCount).To(Equal(0))
+				Expect(apiCheck.cpUnreachableCount).To(Equal(0))
+			})
+		})
+	})
+
+	// Tests for a 2+1 arbiter cluster scenario (2 CP nodes + 1 arbiter worker).
+	Describe("2+1 arbiter cluster scenario", func() {
+		var (
+			peerProvider *mockPeerAddressProvider
+			dialer       *mockPeerDialer
+		)
+
+		BeforeEach(func() {
+			// 2+1 cluster: 2 CP nodes + 1 arbiter worker
+			// From the perspective of CP-1 (our node):
+			// - 1 worker peer (arbiter)
+			// - 1 CP peer (CP-2)
+			peerProvider = &mockPeerAddressProvider{
+				workerAddresses: []corev1.PodIP{
+					{IP: "10.0.0.10"}, // arbiter
+				},
+				controlPlaneAddresses: []corev1.PodIP{
+					{IP: "10.0.0.20"}, // CP-2
+				},
+			}
+			dialer = newMockPeerDialer()
+		})
+
+		Context("when CP-1 is fully network-isolated (NIC down)", func() {
+			It("should detect isolation through canReachAnyPeer", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+
+				// No peers reachable (NIC is down)
+				Expect(apiCheck.canReachAnyPeer()).To(BeFalse())
+
+				// Both peers were attempted
+				Expect(dialer.DialCount()).To(Equal(2))
+			})
+		})
+
+		Context("when only the arbiter is down but CP-2 is reachable", func() {
+			It("should consider the node healthy (partial isolation, not full)", func() {
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+
+				// CP-2 is reachable, arbiter is not
+				dialer.SetReachable("10.0.0.20:30001")
+
+				Expect(apiCheck.canReachAnyPeer()).To(BeTrue())
+			})
+		})
+
+		Context("compact 3-node cluster (all nodes are CP+worker)", func() {
+			It("should deduplicate and check unique peers", func() {
+				// Same IPs in both lists
+				peerProvider.workerAddresses = []corev1.PodIP{
+					{IP: "10.0.0.20"},
+					{IP: "10.0.0.30"},
+				}
+				peerProvider.controlPlaneAddresses = []corev1.PodIP{
+					{IP: "10.0.0.20"},
+					{IP: "10.0.0.30"},
+				}
+
+				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
+				Expect(apiCheck.canReachAnyPeer()).To(BeFalse())
+				// Should only dial 2 unique peers, not 4
+				Expect(dialer.DialCount()).To(Equal(2))
+			})
+		})
+	})
+
+	// Smooth upgrade path: verify that the new PeerAddressProvider interface
+	// is backward compatible with the concrete *peers.Peers type.
+	Describe("PeerAddressProvider interface compatibility", func() {
+		It("should accept *peers.Peers as PeerAddressProvider", func() {
+			// This is a compile-time check — if *peers.Peers doesn't satisfy
+			// PeerAddressProvider, this test file won't compile.
+			var _ PeerAddressProvider = &peers.Peers{}
+		})
+	})
+
+	// Verify the PeerDialer interface contracts.
+	Describe("PeerDialer interface", func() {
+		It("netPeerDialer should implement PeerDialer", func() {
+			var _ PeerDialer = &netPeerDialer{}
+		})
+
+		It("mockPeerDialer should implement PeerDialer", func() {
+			var _ PeerDialer = newMockPeerDialer()
+		})
+	})
+
+	Describe("mockPeerDialer behavior", func() {
+		var dialer *mockPeerDialer
+
+		BeforeEach(func() {
+			dialer = newMockPeerDialer()
+		})
+
+		It("should fail for unknown addresses", func() {
+			err := dialer.Dial("10.0.0.1:30001", time.Second)
+			Expect(err).To(HaveOccurred())
+			Expect(dialer.DialCount()).To(Equal(1))
+		})
+
+		It("should succeed for reachable addresses", func() {
+			dialer.SetReachable("10.0.0.1:30001")
+			err := dialer.Dial("10.0.0.1:30001", time.Second)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should record all dial attempts", func() {
+			dialer.Dial("10.0.0.1:30001", time.Second)
+			dialer.Dial("10.0.0.2:30001", time.Second)
+			dialer.Dial("10.0.0.3:30001", time.Second)
+			Expect(dialer.DialCount()).To(Equal(3))
+		})
 	})
 })

--- a/internal/apicheck/check_test.go
+++ b/internal/apicheck/check_test.go
@@ -379,45 +379,6 @@ var _ = Describe("ApiConnectivityCheck", func() {
 			// for worker nodes.
 		})
 
-		It("should not track cpUnreachableCount on worker nodes", func() {
-			apiCheck.cpUnreachableCount = 0
-			// isConsideredHealthy for worker nodes returns workerPeersResponse.IsHealthy
-			// directly, without touching cpUnreachableCount
-			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
-		})
-	})
-
-	// Tests for the CP isolation escalation logic in isConsideredHealthy.
-	// These test the cpUnreachableCount behavior at the field level since
-	// full isConsideredHealthy requires real gRPC peer infrastructure.
-	Describe("CP isolation escalation — cpUnreachableCount", func() {
-		It("should start at zero", func() {
-			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
-			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
-		})
-
-		It("should be independent of errorCount", func() {
-			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
-			apiCheck.errorCount = 5
-			apiCheck.cpUnreachableCount = 2
-
-			// They track different signals
-			Expect(apiCheck.errorCount).To(Equal(5))
-			Expect(apiCheck.cpUnreachableCount).To(Equal(2))
-		})
-
-		It("should be reset when errorCount is reset (healthy path)", func() {
-			apiCheck = newTestApiCheck(log, &mockPeerAddressProvider{}, newMockPeerDialer(), nil)
-			apiCheck.errorCount = 3
-			apiCheck.cpUnreachableCount = 3
-
-			// Simulating what Start() does when readyz passes and peers are reachable
-			apiCheck.errorCount = 0
-			apiCheck.cpUnreachableCount = 0
-
-			Expect(apiCheck.errorCount).To(Equal(0))
-			Expect(apiCheck.cpUnreachableCount).To(Equal(0))
-		})
 	})
 
 	// Integration-style tests that verify the complete canReachAnyPeer +
@@ -446,7 +407,6 @@ var _ = Describe("ApiConnectivityCheck", func() {
 			It("should reset errorCount when readyz passes and peers are reachable", func() {
 				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
 				apiCheck.errorCount = 2
-				apiCheck.cpUnreachableCount = 1
 
 				// Simulate: readyz passed, peers reachable (this is what Start does)
 				dialer.SetReachable("10.0.0.1:30001")
@@ -455,11 +415,9 @@ var _ = Describe("ApiConnectivityCheck", func() {
 				// Worker path: just reset
 				if !apiCheck.isControlPlane() || apiCheck.canReachAnyPeer() {
 					apiCheck.errorCount = 0
-					apiCheck.cpUnreachableCount = 0
 				}
 
 				Expect(apiCheck.errorCount).To(Equal(0))
-				Expect(apiCheck.cpUnreachableCount).To(Equal(0))
 			})
 		})
 
@@ -488,7 +446,6 @@ var _ = Describe("ApiConnectivityCheck", func() {
 				// reachability check is skipped entirely
 				if !apiCheck.isControlPlane() {
 					apiCheck.errorCount = 0
-					apiCheck.cpUnreachableCount = 0
 				}
 
 				Expect(apiCheck.errorCount).To(Equal(0))
@@ -499,18 +456,15 @@ var _ = Describe("ApiConnectivityCheck", func() {
 			It("should recover when peers become reachable again", func() {
 				apiCheck = newTestApiCheck(log, peerProvider, dialer, nil)
 				apiCheck.errorCount = 2
-				apiCheck.cpUnreachableCount = 2
 
 				// Network recovers — peers become reachable
 				dialer.SetReachable("10.0.0.1:30001")
 
 				if apiCheck.canReachAnyPeer() {
 					apiCheck.errorCount = 0
-					apiCheck.cpUnreachableCount = 0
 				}
 
 				Expect(apiCheck.errorCount).To(Equal(0))
-				Expect(apiCheck.cpUnreachableCount).To(Equal(0))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

Fixes [RHWA-1384](https://redhat.atlassian.net/browse/RHWA-1384) — SNR agent cannot remediate isolated control plane nodes.

On CP nodes, the ClusterIP request can be routed to the local kube-apiserver endpoint. The `/readyz` checks do not provide a signal that detects loss of connectivity to the rest of the cluster, so the error count never increments, peer consultation is never triggered, and the watchdog is fed indefinitely.

### Changes

- **Peer reachability gate on CP nodes**: after readyz passes on a CP node, verify that at least one peer is reachable via lightweight TCP dial against a random sample of up to 3 peers. If no peer is reachable, treat the check as failed and enter the existing `isConsideredHealthy()` error threshold / peer consultation flow. Worker nodes are unaffected.
- **`PeerAddressProvider` interface**: changed `ApiConnectivityCheckConfig.Peers` from `*peers.Peers` to an interface. `*peers.Peers` satisfies it without modification — no changes needed in `cmd/main.go` or any consumer.
- **`PeerDialer` interface**: abstracts TCP dialing for testability.

### What does NOT change

- `/readyz?exclude=shutdown` endpoint and how it is called
- Worker node behavior
- `getWorkerPeersResponse()`, `getControlPlanePeersStatus()`, `IsControlPlaneHealthy()`, `isDiagnosticsPassed()`
- Watchdog feeding/stopping mechanics
- All existing configuration (no new CRD fields)
- `SafeTimeToAssumeNodeRebootedSeconds` calculation
- The OLM bundle

### Design

See `docs/design/cp-isolation-detection.md` for the full design document including root cause analysis, considered alternatives, edge cases, and time-to-remediation analysis.

## Test plan

- [x] 30 unit tests covering: `canReachAnyPeer`, `getAllPeerAddresses`, `isControlPlane`, full flow (CP healthy, CP isolated, worker unchanged, transient recovery), 2+1 arbiter cluster scenarios, compact cluster deduplication, interface compatibility, thread safety
- [x] All tests pass with `-race` flag
- [x] E2E: deployed on a 3x3 OCP cluster, isolated a CP node via EC2 security groups, verified remediation triggered (node rebooted, reached Fencing-Completed, recovered after isolation reverted) — [test notes](https://hackmd.io/@medik8s/SkB23VbBMg) by @weshayutin

