### PR TITLE
Add production-readiness settings to DaemonSet agent

### DIFF
--- a/e2e/self_node_remediation_test.go
+++ b/e2e/self_node_remediation_test.go
@@ -13,11 +13,13 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/medik8s/self-node-remediation/api/v1alpha1"
@@ -440,6 +442,40 @@ func deleteAndWait(resource client.Object) {
 }
 
 func ensureSnrRunning(nodes *v1.NodeList) {
+	// Wait for DaemonSet rollout to complete after operator upgrade
+	// This ensures we're checking pods from the current template, not old ones
+	ctx := context.Background()
+	dsName := "self-node-remediation-ds"
+
+	EventuallyWithOffset(1, func() bool {
+		ds := &appsv1.DaemonSet{}
+		err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      dsName,
+			Namespace: testNamespace,
+		}, ds)
+		if err != nil {
+			GinkgoWriter.Printf("Failed to get DaemonSet %s: %v\n", dsName, err)
+			return false
+		}
+
+		// Check if rollout is complete: all pods updated and ready
+		isComplete := ds.Status.DesiredNumberScheduled > 0 &&
+			ds.Status.DesiredNumberScheduled == ds.Status.UpdatedNumberScheduled &&
+			ds.Status.DesiredNumberScheduled == ds.Status.NumberReady &&
+			ds.Status.NumberUnavailable == 0
+
+		if !isComplete {
+			GinkgoWriter.Printf("DaemonSet %s rollout in progress: desired=%d, updated=%d, ready=%d, unavailable=%d\n",
+				dsName,
+				ds.Status.DesiredNumberScheduled,
+				ds.Status.UpdatedNumberScheduled,
+				ds.Status.NumberReady,
+				ds.Status.NumberUnavailable)
+		}
+
+		return isComplete
+	}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "DaemonSet rollout did not complete")
+
 	wg := sync.WaitGroup{}
 	for i := range nodes.Items {
 		wg.Add(1)

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -39,6 +39,7 @@ spec:
       containers:
       - args:
         - --is-manager=false
+        - --health-probe-bind-address=:8081
         command:
         - /manager
         env:

--- a/install/self-node-remediation-deamonset.yaml
+++ b/install/self-node-remediation-deamonset.yaml
@@ -75,7 +75,24 @@ spec:
           - name: MIN_PEERS_FOR_REMEDIATION
             value: "{{.MinPeersForRemediation}}"
         image: {{.Image}}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          failureThreshold: 12
+          periodSeconds: 5
         volumeMounts:
           - name: devices
             mountPath: /dev
@@ -92,7 +109,7 @@ spec:
             cpu: 20m
             memory: 60Mi
         terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        terminationMessagePolicy: FallbackToLogsOnError
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
+++ b/internal/controller/tests/config/selfnoderemediationconfig_controller_test.go
@@ -122,6 +122,23 @@ var _ = Describe("SNR Config Test", func() {
 			Expect(container.SecurityContext).ToNot(BeNil())
 			Expect(container.SecurityContext.Privileged).To(Equal(pointer.Bool(true)))
 			Expect(container.SecurityContext.ReadOnlyRootFilesystem).To(Equal(pointer.Bool(true)))
+
+			Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+
+			Expect(container.LivenessProbe).ToNot(BeNil())
+			Expect(container.LivenessProbe.HTTPGet.Path).To(Equal("/healthz"))
+			Expect(container.LivenessProbe.HTTPGet.Port.IntValue()).To(Equal(8081))
+
+			Expect(container.ReadinessProbe).ToNot(BeNil())
+			Expect(container.ReadinessProbe.HTTPGet.Path).To(Equal("/readyz"))
+			Expect(container.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(8081))
+
+			Expect(container.StartupProbe).ToNot(BeNil())
+			Expect(container.StartupProbe.HTTPGet.Path).To(Equal("/healthz"))
+			Expect(container.StartupProbe.HTTPGet.Port.IntValue()).To(Equal(8081))
+			Expect(container.StartupProbe.FailureThreshold).To(BeEquivalentTo(12))
+
+			Expect(container.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))
 		})
 		When("Configuration has customized tolerations", func() {
 			var expectedToleration corev1.Toleration


### PR DESCRIPTION
## Why we need this PR

The DaemonSet agent runs on every node but lacks the production-readiness settings already present on the controller-manager: no health probes (kubelet cannot detect or restart a hung agent), `imagePullPolicy: Always` (agent pods fail to start when the registry is unreachable), and crash output is lost (`terminationMessagePolicy: File`). This PR adds the same settings established for the controller-manager in PR #300, adapted for the DaemonSet's design.

Related: [RHWA-1616](https://redhat.atlassian.net/browse/RHWA-1616)

## Changes made

Applied production-readiness settings to `install/self-node-remediation-deamonset.yaml`:

| Change | Detail |
|--------|--------|
| `imagePullPolicy` | `Always` to `IfNotPresent` |
| `livenessProbe` | httpGet `/healthz:8081`, period 20s |
| `readinessProbe` | httpGet `/readyz:8081`, initialDelay 5s, period 10s |
| `startupProbe` | httpGet `/healthz:8081`, failureThreshold 12, period 5s (60s budget) |
| `terminationMessagePolicy` | `File` to `FallbackToLogsOnError` |

The agent registers `/healthz` and `/readyz` endpoints via controller-runtime's health probe server on port 8081 (`cmd/main.go:281-288`), used by both manager and agent modes.

**Note:** Lifecycle hooks (`preStop`, `postStart`) are intentionally omitted. The DS agent is not behind a Service, so `preStop` sleep has no endpoints to drain. `postStart /bin/true` is a no-op with no operational value. Omitting both avoids adding complexity that serves no purpose for the agent's architecture.

## Test plan

- [x] DaemonSet pods start and operate normally with new settings
- [x] Probes respond correctly on port 8081
- [x] Peer health checking works with `IfNotPresent` pull policy
- [x] Remediation flow (watchdog + software reboot) unaffected